### PR TITLE
feat: first-run state guard for dot CLI

### DIFF
--- a/cmd/dot/adopt.go
+++ b/cmd/dot/adopt.go
@@ -80,6 +80,10 @@ For shell glob expansion, specify package name:
 
 // runAdoptCommand routes to interactive or traditional mode based on arguments.
 func runAdoptCommand(cmd *cobra.Command, args []string, scanDirs, excludeDirs []string, maxSizeStr string) error {
+	if err := runStateGuard(cmd); err != nil {
+		return err
+	}
+
 	// No arguments → Interactive mode
 	if len(args) == 0 {
 		return runAdoptInteractive(cmd, scanDirs, excludeDirs, maxSizeStr)

--- a/cmd/dot/clone.go
+++ b/cmd/dot/clone.go
@@ -100,6 +100,10 @@ Examples:
 
 // runClone handles the clone command execution.
 func runClone(cmd *cobra.Command, args []string, profile string, interactive bool, force bool, branch string) error {
+	if err := runStateGuard(cmd); err != nil {
+		return err
+	}
+
 	repoURL := args[0]
 
 	// Check if --dir flag was explicitly provided

--- a/cmd/dot/manage.go
+++ b/cmd/dot/manage.go
@@ -45,6 +45,10 @@ Examples:
 
 // runManage handles the manage command execution.
 func runManage(cmd *cobra.Command, args []string) error {
+	if err := runStateGuard(cmd); err != nil {
+		return err
+	}
+
 	cfg, err := buildConfigWithCmd(cmd)
 	if err != nil {
 		fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)

--- a/cmd/dot/state_guard.go
+++ b/cmd/dot/state_guard.go
@@ -20,13 +20,14 @@ func runStateGuard(cmd *cobra.Command) error {
 	skip := GetCLIFlags().batch || !terminal.IsInteractive()
 
 	result, err := stateguard.Check(context.Background(), stateguard.GuardOptions{
-		In:          cmd.InOrStdin(),
-		Out:         cmd.ErrOrStderr(),
-		Skip:        skip,
-		ManifestDir: manifestDir,
-		TargetDir:   targetDir,
-		ConfigPath:  configPath,
-		HomeDir:     homeDir,
+		In:           cmd.InOrStdin(),
+		Out:          cmd.ErrOrStderr(),
+		Skip:         skip,
+		ColorEnabled: shouldUseColor(),
+		ManifestDir:  manifestDir,
+		TargetDir:    targetDir,
+		ConfigPath:   configPath,
+		HomeDir:      homeDir,
 	})
 	if err != nil {
 		return err

--- a/cmd/dot/state_guard.go
+++ b/cmd/dot/state_guard.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/yaklabco/dot/internal/cli/terminal"
+	"github.com/yaklabco/dot/internal/config"
+	"github.com/yaklabco/dot/internal/stateguard"
+)
+
+// runStateGuard checks for existing dot state on first mutating command
+// and lets the user choose how to proceed. Returns nil if no action needed.
+func runStateGuard(cmd *cobra.Command) error {
+	manifestDir, targetDir, configPath, homeDir := resolveGuardPaths()
+
+	skip := GetCLIFlags().batch || !terminal.IsInteractive()
+
+	result, err := stateguard.Check(context.Background(), stateguard.GuardOptions{
+		In:          cmd.InOrStdin(),
+		Out:         cmd.ErrOrStderr(),
+		Skip:        skip,
+		ManifestDir: manifestDir,
+		TargetDir:   targetDir,
+		ConfigPath:  configPath,
+		HomeDir:     homeDir,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Silence is golden for noop and already-acknowledged
+	_ = result
+	return nil
+}
+
+// resolveGuardPaths determines the manifest dir, target dir, config path,
+// and home dir from config and flags.
+func resolveGuardPaths() (manifestDir, targetDir, configPath, homeDir string) {
+	homeDir, _ = os.UserHomeDir()
+	if homeDir == "" {
+		homeDir, _ = filepath.Abs(".")
+	}
+
+	configPath = getConfigFilePath()
+	extCfg, _ := loadConfigWithRepoPriority(GetCLIFlags().packageDir, configPath)
+
+	if extCfg != nil && extCfg.Directories.Manifest != "" {
+		manifestDir = extCfg.Directories.Manifest
+	} else {
+		manifestDir = config.GetXDGDataPath("dot/manifest")
+	}
+
+	if extCfg != nil && extCfg.Directories.Target != "" && filepath.IsAbs(extCfg.Directories.Target) {
+		targetDir = extCfg.Directories.Target
+	} else {
+		targetDir = homeDir
+	}
+
+	return
+}

--- a/cmd/dot/state_guard_test.go
+++ b/cmd/dot/state_guard_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaklabco/dot/internal/stateguard"
+)
+
+func TestRunStateGuard_NoState(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	cmd := newManageCommand()
+	cmd.SetArgs([]string{})
+	err := runStateGuard(cmd)
+	assert.NoError(t, err)
+}
+
+func TestRunStateGuard_MarkerExists(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	require.NoError(t, stateguard.WriteMarker())
+
+	cmd := newManageCommand()
+	cmd.SetArgs([]string{})
+	err := runStateGuard(cmd)
+	assert.NoError(t, err)
+}
+
+func TestRunStateGuard_BatchMode(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	dataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+
+	// Write manifest into the path resolveGuardPaths will compute
+	manifestDir := filepath.Join(dataHome, "dot", "manifest")
+	require.NoError(t, os.MkdirAll(manifestDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(manifestDir, ".dot-manifest.json"), []byte(`{
+		"version": "1.0",
+		"packages": {"shell": {"name": "shell", "links": [".bashrc"], "link_count": 1}}
+	}`), 0644))
+
+	// In batch mode, should auto-continue without interactive prompt
+	cliFlags.batch = true
+	defer func() { cliFlags.batch = false }()
+
+	cmd := newManageCommand()
+	cmd.SetArgs([]string{})
+	err := runStateGuard(cmd)
+	assert.NoError(t, err)
+	assert.True(t, stateguard.MarkerExists())
+}
+
+func TestResolveGuardPaths(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", "/tmp/test-data")
+	t.Setenv("XDG_CONFIG_HOME", "/tmp/test-config")
+
+	manifestDir, targetDir, configPath, homeDir := resolveGuardPaths()
+
+	assert.NotEmpty(t, manifestDir)
+	assert.NotEmpty(t, targetDir)
+	assert.NotEmpty(t, configPath)
+	assert.NotEmpty(t, homeDir)
+}

--- a/internal/cli/prompt/prompt.go
+++ b/internal/cli/prompt/prompt.go
@@ -120,3 +120,43 @@ func (p *Prompter) Select(message string, options []string) (int, error) {
 
 	return selection, nil
 }
+
+// SelectWithDefault prompts the user to choose from a list of options with a default.
+// Returns the index of the selected option (0-based).
+// On empty input or EOF, returns defaultIdx.
+func (p *Prompter) SelectWithDefault(message string, options []string, defaultIdx int) (int, error) {
+	fmt.Fprintln(p.out, message)
+	for i, opt := range options {
+		fmt.Fprintf(p.out, "  %d) %s\n", i+1, opt)
+	}
+	fmt.Fprintf(p.out, "Select [1-%d] (default: %d): ", len(options), defaultIdx+1)
+
+	scanner := bufio.NewScanner(p.in)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return -1, fmt.Errorf("read input: %w", err)
+		}
+		// EOF - return default
+		return defaultIdx, nil
+	}
+
+	answer := strings.TrimSpace(scanner.Text())
+
+	// Empty input returns default
+	if answer == "" {
+		return defaultIdx, nil
+	}
+
+	var selection int
+	if _, err := fmt.Sscanf(answer, "%d", &selection); err != nil {
+		return -1, nil
+	}
+
+	// Convert to 0-based index and validate range
+	selection--
+	if selection < 0 || selection >= len(options) {
+		return -1, nil
+	}
+
+	return selection, nil
+}

--- a/internal/cli/prompt/prompt_test.go
+++ b/internal/cli/prompt/prompt_test.go
@@ -240,6 +240,93 @@ func TestSelect(t *testing.T) {
 	}
 }
 
+func TestSelectWithDefault(t *testing.T) {
+	options := []string{"Continue", "Start fresh", "Back up and start fresh"}
+
+	tests := []struct {
+		name       string
+		input      string
+		defaultIdx int
+		expected   int
+	}{
+		{
+			name:       "select first option",
+			input:      "1\n",
+			defaultIdx: 0,
+			expected:   0,
+		},
+		{
+			name:       "select second option",
+			input:      "2\n",
+			defaultIdx: 0,
+			expected:   1,
+		},
+		{
+			name:       "select third option",
+			input:      "3\n",
+			defaultIdx: 0,
+			expected:   2,
+		},
+		{
+			name:       "empty input returns default (first)",
+			input:      "\n",
+			defaultIdx: 0,
+			expected:   0,
+		},
+		{
+			name:       "empty input returns default (second)",
+			input:      "\n",
+			defaultIdx: 1,
+			expected:   1,
+		},
+		{
+			name:       "invalid selection (out of range)",
+			input:      "4\n",
+			defaultIdx: 0,
+			expected:   -1,
+		},
+		{
+			name:       "invalid selection (text)",
+			input:      "abc\n",
+			defaultIdx: 0,
+			expected:   -1,
+		},
+		{
+			name:       "invalid selection (zero)",
+			input:      "0\n",
+			defaultIdx: 0,
+			expected:   -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := strings.NewReader(tt.input)
+			out := &bytes.Buffer{}
+			p := New(in, out)
+
+			result, err := p.SelectWithDefault("Choose an option", options, tt.defaultIdx)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+			assert.Contains(t, out.String(), "Choose an option")
+			assert.Contains(t, out.String(), "1) Continue")
+			assert.Contains(t, out.String(), "2) Start fresh")
+			assert.Contains(t, out.String(), "3) Back up and start fresh")
+			assert.Contains(t, out.String(), "(default:")
+		})
+	}
+}
+
+func TestSelectWithDefault_EOF(t *testing.T) {
+	in := strings.NewReader("")
+	out := &bytes.Buffer{}
+	p := New(in, out)
+
+	result, err := p.SelectWithDefault("Choose", []string{"A", "B"}, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result)
+}
+
 func TestConfirm_EOF(t *testing.T) {
 	in := strings.NewReader("")
 	out := &bytes.Buffer{}

--- a/internal/config/extended.go
+++ b/internal/config/extended.go
@@ -230,13 +230,13 @@ func DefaultExtended() *ExtendedConfig {
 		Directories: DirectoriesConfig{
 			Package:  ".",
 			Target:   homeDir,
-			Manifest: getXDGDataPath("dot/manifest"),
+			Manifest: GetXDGDataPath("dot/manifest"),
 		},
 		Logging: LoggingConfig{
 			Level:       "INFO",
 			Format:      "text",
 			Destination: "stderr",
-			File:        getXDGStatePath("dot/dot.log"),
+			File:        GetXDGStatePath("dot/dot.log"),
 		},
 		Symlinks: SymlinksConfig{
 			Mode:         "relative",
@@ -532,8 +532,8 @@ func (c *ExtendedConfig) validateNetwork() error {
 	return nil
 }
 
-// getXDGDataPath returns XDG data directory path.
-func getXDGDataPath(suffix string) string {
+// GetXDGDataPath returns XDG data directory path.
+func GetXDGDataPath(suffix string) string {
 	if dataHome := os.Getenv("XDG_DATA_HOME"); dataHome != "" {
 		return filepath.Join(dataHome, suffix)
 	}
@@ -544,8 +544,8 @@ func getXDGDataPath(suffix string) string {
 	return filepath.Join(homeDir, ".local", "share", suffix)
 }
 
-// getXDGStatePath returns XDG state directory path.
-func getXDGStatePath(suffix string) string {
+// GetXDGStatePath returns XDG state directory path.
+func GetXDGStatePath(suffix string) string {
 	if stateHome := os.Getenv("XDG_STATE_HOME"); stateHome != "" {
 		return filepath.Join(stateHome, suffix)
 	}

--- a/internal/stateguard/actions.go
+++ b/internal/stateguard/actions.go
@@ -1,0 +1,184 @@
+package stateguard
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/yaklabco/dot/internal/adapters"
+	"github.com/yaklabco/dot/internal/domain"
+	"github.com/yaklabco/dot/internal/manifest"
+)
+
+// ExistingState describes the detected state of a previous dot installation.
+type ExistingState struct {
+	ManifestPath string
+	PackageCount int
+	LinkCount    int
+}
+
+// DetectExistingState loads the manifest and counts packages/links.
+// Returns nil if no manifest exists or the manifest is empty.
+func DetectExistingState(ctx context.Context, manifestDir, targetDir string) (*ExistingState, error) {
+	store := manifest.NewFSManifestStoreWithDir(adapters.NewOSFilesystem(), manifestDir)
+	targetPath := domain.NewTargetPath(targetDir)
+	if targetPath.IsErr() {
+		return nil, targetPath.UnwrapErr()
+	}
+
+	result := store.Load(ctx, targetPath.Unwrap())
+	if result.IsErr() {
+		return nil, result.UnwrapErr()
+	}
+
+	m := result.Unwrap()
+	if len(m.Packages) == 0 {
+		return nil, nil
+	}
+
+	linkCount := 0
+	for _, pkg := range m.Packages {
+		linkCount += len(pkg.Links)
+	}
+
+	return &ExistingState{
+		ManifestPath: filepath.Join(manifestDir, ".dot-manifest.json"),
+		PackageCount: len(m.Packages),
+		LinkCount:    linkCount,
+	}, nil
+}
+
+// ActionContinue writes the marker and returns.
+func ActionContinue() error {
+	return WriteMarker()
+}
+
+// ActionFresh removes managed symlinks, deletes the manifest, and writes the marker.
+// Regular files referenced in the manifest are preserved (only symlinks are removed).
+func ActionFresh(manifestDir, targetDir string) error {
+	ctx := context.Background()
+	store := manifest.NewFSManifestStoreWithDir(adapters.NewOSFilesystem(), manifestDir)
+	targetPath := domain.NewTargetPath(targetDir)
+	if targetPath.IsErr() {
+		return targetPath.UnwrapErr()
+	}
+
+	result := store.Load(ctx, targetPath.Unwrap())
+	if result.IsErr() {
+		return result.UnwrapErr()
+	}
+
+	m := result.Unwrap()
+	var errs []error
+	for _, pkg := range m.Packages {
+		pkgTargetDir := targetDir
+		if pkg.TargetDir != "" {
+			pkgTargetDir = pkg.TargetDir
+		}
+		for _, link := range pkg.Links {
+			linkPath := filepath.Join(pkgTargetDir, link)
+			fi, err := os.Lstat(linkPath)
+			if err != nil {
+				continue // Skip non-existent links
+			}
+			if fi.Mode()&os.ModeSymlink != 0 {
+				if err := os.Remove(linkPath); err != nil {
+					errs = append(errs, fmt.Errorf("remove symlink %s: %w", linkPath, err))
+				}
+			}
+		}
+	}
+
+	// Remove manifest file
+	manifestPath := filepath.Join(manifestDir, ".dot-manifest.json")
+	if err := os.Remove(manifestPath); err != nil && !os.IsNotExist(err) {
+		errs = append(errs, fmt.Errorf("remove manifest: %w", err))
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return WriteMarker()
+}
+
+// ActionBackupAndFresh copies the manifest and config to a backup directory,
+// then delegates to ActionFresh. Returns the backup directory path.
+func ActionBackupAndFresh(manifestDir, targetDir, configPath, homeDir string) (string, error) {
+	backupDir, err := resolveBackupDir(homeDir)
+	if err != nil {
+		return "", fmt.Errorf("create backup directory: %w", err)
+	}
+
+	// Copy manifest
+	manifestSrc := filepath.Join(manifestDir, ".dot-manifest.json")
+	if _, err := os.Stat(manifestSrc); err == nil {
+		manifestBackupDir := filepath.Join(backupDir, "manifest")
+		if err := os.MkdirAll(manifestBackupDir, 0755); err != nil {
+			return "", fmt.Errorf("create manifest backup dir: %w", err)
+		}
+		if err := copyFile(manifestSrc, filepath.Join(manifestBackupDir, ".dot-manifest.json")); err != nil {
+			return "", fmt.Errorf("backup manifest: %w", err)
+		}
+	}
+
+	// Copy config
+	if configPath != "" {
+		if _, err := os.Stat(configPath); err == nil {
+			if err := copyFile(configPath, filepath.Join(backupDir, filepath.Base(configPath))); err != nil {
+				return "", fmt.Errorf("backup config: %w", err)
+			}
+		}
+	}
+
+	if err := ActionFresh(manifestDir, targetDir); err != nil {
+		return backupDir, err
+	}
+
+	return backupDir, nil
+}
+
+// PrintSummary writes the detected state summary to the writer.
+func PrintSummary(w io.Writer, state *ExistingState) {
+	fmt.Fprintln(w, "Existing dot installation detected.")
+	fmt.Fprintf(w, "  %d packages · %d symlinks · manifest: %s\n\n",
+		state.PackageCount, state.LinkCount, state.ManifestPath)
+}
+
+func resolveBackupDir(homeDir string) (string, error) {
+	today := time.Now().Format("20060102")
+	base := filepath.Join(homeDir, ".dot-backup-"+today)
+
+	// Try the base name first
+	if _, err := os.Stat(base); os.IsNotExist(err) {
+		if err := os.MkdirAll(base, 0755); err != nil {
+			return "", err
+		}
+		return base, nil
+	}
+
+	// Append -2, -3, etc. on collision
+	for i := 2; i <= 99; i++ {
+		candidate := fmt.Sprintf("%s-%d", base, i)
+		if _, err := os.Stat(candidate); os.IsNotExist(err) {
+			if err := os.MkdirAll(candidate, 0755); err != nil {
+				return "", err
+			}
+			return candidate, nil
+		}
+	}
+
+	return "", fmt.Errorf("too many backup directories for %s", base)
+}
+
+func copyFile(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, 0644)
+}

--- a/internal/stateguard/actions.go
+++ b/internal/stateguard/actions.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -140,13 +139,6 @@ func ActionBackupAndFresh(manifestDir, targetDir, configPath, homeDir string) (s
 	}
 
 	return backupDir, nil
-}
-
-// PrintSummary writes the detected state summary to the writer.
-func PrintSummary(w io.Writer, state *ExistingState) {
-	fmt.Fprintln(w, "Existing dot installation detected.")
-	fmt.Fprintf(w, "  %d packages · %d symlinks · manifest: %s\n\n",
-		state.PackageCount, state.LinkCount, state.ManifestPath)
 }
 
 func resolveBackupDir(homeDir string) (string, error) {

--- a/internal/stateguard/actions_test.go
+++ b/internal/stateguard/actions_test.go
@@ -1,0 +1,240 @@
+package stateguard
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaklabco/dot/internal/manifest"
+)
+
+// writeTestManifest creates a manifest file with the given packages in dir.
+func writeTestManifest(t *testing.T, dir string, pkgs map[string]manifest.PackageInfo) {
+	t.Helper()
+	m := manifest.New()
+	for name, pkg := range pkgs {
+		pkg.Name = name
+		m.AddPackage(pkg)
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".dot-manifest.json"), data, 0644))
+}
+
+func TestActionContinue(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+
+	require.NoError(t, ActionContinue())
+	assert.True(t, MarkerExists())
+}
+
+func TestActionFresh_RemovesSymlinks(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	targetDir := t.TempDir()
+	manifestDir := t.TempDir()
+
+	// Create a real file and a symlink in the target directory
+	realFile := filepath.Join(targetDir, "realfile.txt")
+	require.NoError(t, os.WriteFile(realFile, []byte("keep me"), 0644))
+
+	symlinkPath := filepath.Join(targetDir, ".bashrc")
+	require.NoError(t, os.Symlink("/some/source/.bashrc", symlinkPath))
+
+	// Create manifest referencing both
+	writeTestManifest(t, manifestDir, map[string]manifest.PackageInfo{
+		"shell": {
+			Links:     []string{".bashrc", "realfile.txt"},
+			LinkCount: 2,
+			TargetDir: targetDir,
+		},
+	})
+
+	require.NoError(t, ActionFresh(manifestDir, targetDir))
+
+	// Symlink should be removed
+	_, err := os.Lstat(symlinkPath)
+	assert.True(t, os.IsNotExist(err), "symlink should be removed")
+
+	// Regular file should be preserved
+	_, err = os.Stat(realFile)
+	assert.NoError(t, err, "regular file should be preserved")
+
+	// Manifest file should be removed
+	_, err = os.Stat(filepath.Join(manifestDir, ".dot-manifest.json"))
+	assert.True(t, os.IsNotExist(err), "manifest should be removed")
+
+	// Marker should be written
+	assert.True(t, MarkerExists())
+}
+
+func TestActionFresh_SkipsNonExistentLinks(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	targetDir := t.TempDir()
+	manifestDir := t.TempDir()
+
+	writeTestManifest(t, manifestDir, map[string]manifest.PackageInfo{
+		"shell": {
+			Links:     []string{".bashrc", ".zshrc"},
+			LinkCount: 2,
+			TargetDir: targetDir,
+		},
+	})
+
+	// Neither link exists, should not error
+	require.NoError(t, ActionFresh(manifestDir, targetDir))
+	assert.True(t, MarkerExists())
+}
+
+func TestActionBackupAndFresh(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	targetDir := t.TempDir()
+	manifestDir := t.TempDir()
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+
+	// Create config file
+	require.NoError(t, os.WriteFile(configPath, []byte("logging:\n  level: DEBUG\n"), 0644))
+
+	// Create symlink in target
+	symlinkPath := filepath.Join(targetDir, ".bashrc")
+	require.NoError(t, os.Symlink("/some/source/.bashrc", symlinkPath))
+
+	// Create manifest
+	writeTestManifest(t, manifestDir, map[string]manifest.PackageInfo{
+		"shell": {
+			Links:     []string{".bashrc"},
+			LinkCount: 1,
+			TargetDir: targetDir,
+		},
+	})
+
+	homeDir := t.TempDir()
+	backupDir, err := ActionBackupAndFresh(manifestDir, targetDir, configPath, homeDir)
+	require.NoError(t, err)
+
+	// Backup directory should exist and contain manifest + config
+	assert.DirExists(t, backupDir)
+
+	manifestBackup := filepath.Join(backupDir, "manifest", ".dot-manifest.json")
+	assert.FileExists(t, manifestBackup)
+
+	configBackup := filepath.Join(backupDir, "config.yaml")
+	assert.FileExists(t, configBackup)
+
+	// Original symlink should be removed
+	_, err = os.Lstat(symlinkPath)
+	assert.True(t, os.IsNotExist(err))
+
+	// Marker should be written
+	assert.True(t, MarkerExists())
+}
+
+func TestActionBackupAndFresh_CollisionHandling(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	homeDir := t.TempDir()
+	targetDir := t.TempDir()
+	manifestDir := t.TempDir()
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("test"), 0644))
+
+	writeTestManifest(t, manifestDir, map[string]manifest.PackageInfo{
+		"shell": {
+			Links:     []string{},
+			LinkCount: 0,
+			TargetDir: targetDir,
+		},
+	})
+
+	// Pre-create the backup dir to force collision
+	today := time.Now().Format("20060102")
+	existingBackup := filepath.Join(homeDir, ".dot-backup-"+today)
+	require.NoError(t, os.MkdirAll(existingBackup, 0755))
+
+	backupDir, err := ActionBackupAndFresh(manifestDir, targetDir, configPath, homeDir)
+	require.NoError(t, err)
+
+	// Should have created a suffixed backup directory
+	assert.NotEqual(t, existingBackup, backupDir)
+	assert.Contains(t, backupDir, ".dot-backup-"+today+"-2")
+}
+
+func TestActionFresh_UsesManifestTargetDir(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	targetDir := t.TempDir()
+	manifestDir := t.TempDir()
+
+	// Create symlink in actual target dir (not the default)
+	customTarget := t.TempDir()
+	symlinkPath := filepath.Join(customTarget, ".vimrc")
+	require.NoError(t, os.Symlink("/some/source/.vimrc", symlinkPath))
+
+	writeTestManifest(t, manifestDir, map[string]manifest.PackageInfo{
+		"vim": {
+			Links:     []string{".vimrc"},
+			LinkCount: 1,
+			TargetDir: customTarget,
+		},
+	})
+
+	require.NoError(t, ActionFresh(manifestDir, targetDir))
+
+	// Symlink in custom target should be removed
+	_, err := os.Lstat(symlinkPath)
+	assert.True(t, os.IsNotExist(err))
+}
+
+// detectExistingStateHelper loads a manifest and counts packages/links for testing.
+func detectExistingStateHelper(t *testing.T, manifestDir, targetDir string) *ExistingState {
+	t.Helper()
+	ctx := context.Background()
+	state, err := DetectExistingState(ctx, manifestDir, targetDir)
+	require.NoError(t, err)
+	return state
+}
+
+func TestDetectExistingState_EmptyManifest(t *testing.T) {
+	manifestDir := t.TempDir()
+	targetDir := t.TempDir()
+
+	state := detectExistingStateHelper(t, manifestDir, targetDir)
+	assert.Nil(t, state, "empty manifest should return nil state")
+}
+
+func TestDetectExistingState_WithPackages(t *testing.T) {
+	manifestDir := t.TempDir()
+	targetDir := t.TempDir()
+
+	writeTestManifest(t, manifestDir, map[string]manifest.PackageInfo{
+		"shell": {
+			Links:     []string{".bashrc", ".zshrc"},
+			LinkCount: 2,
+		},
+		"vim": {
+			Links:     []string{".vimrc"},
+			LinkCount: 1,
+		},
+	})
+
+	state := detectExistingStateHelper(t, manifestDir, targetDir)
+	require.NotNil(t, state)
+	assert.Equal(t, 2, state.PackageCount)
+	assert.Equal(t, 3, state.LinkCount)
+	assert.Contains(t, state.ManifestPath, ".dot-manifest.json")
+}

--- a/internal/stateguard/guard.go
+++ b/internal/stateguard/guard.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/yaklabco/dot/internal/cli/output"
 	"github.com/yaklabco/dot/internal/cli/prompt"
+	"github.com/yaklabco/dot/internal/cli/render"
 )
 
 // CheckResult indicates the outcome of the state guard check.
@@ -26,13 +28,14 @@ const (
 
 // GuardOptions configures the state guard check.
 type GuardOptions struct {
-	In          io.Reader
-	Out         io.Writer
-	Skip        bool   // Auto-continue without prompting (batch mode / non-TTY)
-	ManifestDir string // Directory containing the manifest file
-	TargetDir   string // Target directory for symlinks
-	ConfigPath  string // Path to the config file (for backup)
-	HomeDir     string // Home directory (for backup location)
+	In           io.Reader
+	Out          io.Writer
+	Skip         bool   // Auto-continue without prompting (batch mode / non-TTY)
+	ColorEnabled bool   // Whether to use colored output
+	ManifestDir  string // Directory containing the manifest file
+	TargetDir    string // Target directory for symlinks
+	ConfigPath   string // Path to the config file (for backup)
+	HomeDir      string // Home directory (for backup location)
 }
 
 // Check is the main entry point for the first-run state guard.
@@ -55,13 +58,26 @@ func Check(ctx context.Context, opts GuardOptions) (CheckResult, error) {
 		return ResultContinue, ActionContinue()
 	}
 
-	// Show summary and prompt
-	PrintSummary(opts.Out, state)
+	f := output.NewFormatter(opts.Out, opts.ColorEnabled)
+	c := render.NewColorizer(opts.ColorEnabled)
 
+	// Show summary
+	f.BlankLine()
+	f.Warning("Existing dot installation detected")
+	f.BlankLine()
+	f.Bullet(fmt.Sprintf("%s  %s  %s",
+		c.Bold(fmt.Sprintf("%d %s", state.PackageCount, pluralize(state.PackageCount, "package", "packages"))),
+		c.Dim("·"),
+		c.Bold(fmt.Sprintf("%d %s", state.LinkCount, pluralize(state.LinkCount, "symlink", "symlinks"))),
+	))
+	f.Bullet(fmt.Sprintf("%s %s", c.Dim("manifest:"), c.Dim(state.ManifestPath)))
+	f.BlankLine()
+
+	// Prompt
 	options := []string{
-		"Continue — use the existing installation as-is",
-		"Start fresh — remove all managed symlinks and manifest",
-		"Back up and start fresh — archive state then reset",
+		fmt.Sprintf("%s — use the existing installation as-is", c.Bold("Continue")),
+		fmt.Sprintf("%s — remove all managed symlinks and manifest", c.Bold("Start fresh")),
+		fmt.Sprintf("%s — archive state then reset", c.Bold("Back up and start fresh")),
 	}
 
 	p := prompt.New(opts.In, opts.Out)
@@ -70,23 +86,39 @@ func Check(ctx context.Context, opts GuardOptions) (CheckResult, error) {
 		return ResultNoop, fmt.Errorf("prompt: %w", err)
 	}
 
+	f.BlankLine()
+
 	switch choice {
 	case 0:
+		f.SuccessSimple("Continuing with existing installation")
+		f.BlankLine()
 		return ResultContinue, ActionContinue()
 	case 1:
 		if err := ActionFresh(opts.ManifestDir, opts.TargetDir); err != nil {
 			return ResultFresh, fmt.Errorf("start fresh: %w", err)
 		}
+		f.SuccessSimple("Removed managed symlinks and manifest")
+		f.BlankLine()
 		return ResultFresh, nil
 	case 2:
 		backupDir, err := ActionBackupAndFresh(opts.ManifestDir, opts.TargetDir, opts.ConfigPath, opts.HomeDir)
 		if err != nil {
 			return ResultBackupAndFresh, fmt.Errorf("backup and start fresh: %w", err)
 		}
-		fmt.Fprintf(opts.Out, "Backed up to: %s\n", backupDir)
+		f.SuccessSimple(fmt.Sprintf("Backed up to %s", c.Accent(backupDir)))
+		f.BlankLine()
 		return ResultBackupAndFresh, nil
 	default:
 		// Invalid selection or cancelled: default to continue
+		f.SuccessSimple("Continuing with existing installation")
+		f.BlankLine()
 		return ResultContinue, ActionContinue()
 	}
+}
+
+func pluralize(count int, singular, plural string) string {
+	if count == 1 {
+		return singular
+	}
+	return plural
 }

--- a/internal/stateguard/guard.go
+++ b/internal/stateguard/guard.go
@@ -1,0 +1,92 @@
+package stateguard
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/yaklabco/dot/internal/cli/prompt"
+)
+
+// CheckResult indicates the outcome of the state guard check.
+type CheckResult int
+
+const (
+	// ResultNoop means no existing state was found (true first run).
+	ResultNoop CheckResult = iota
+	// ResultAlreadyAcknowledged means the marker file already exists.
+	ResultAlreadyAcknowledged
+	// ResultContinue means the user chose to continue with existing state.
+	ResultContinue
+	// ResultFresh means the user chose to start fresh.
+	ResultFresh
+	// ResultBackupAndFresh means the user chose to back up then start fresh.
+	ResultBackupAndFresh
+)
+
+// GuardOptions configures the state guard check.
+type GuardOptions struct {
+	In          io.Reader
+	Out         io.Writer
+	Skip        bool   // Auto-continue without prompting (batch mode / non-TTY)
+	ManifestDir string // Directory containing the manifest file
+	TargetDir   string // Target directory for symlinks
+	ConfigPath  string // Path to the config file (for backup)
+	HomeDir     string // Home directory (for backup location)
+}
+
+// Check is the main entry point for the first-run state guard.
+// It detects existing state and prompts the user for action.
+func Check(ctx context.Context, opts GuardOptions) (CheckResult, error) {
+	if MarkerExists() {
+		return ResultAlreadyAcknowledged, nil
+	}
+
+	state, err := DetectExistingState(ctx, opts.ManifestDir, opts.TargetDir)
+	if err != nil {
+		return ResultNoop, fmt.Errorf("detect existing state: %w", err)
+	}
+	if state == nil {
+		return ResultNoop, nil
+	}
+
+	// Skip mode (batch / non-TTY): auto-continue
+	if opts.Skip {
+		return ResultContinue, ActionContinue()
+	}
+
+	// Show summary and prompt
+	PrintSummary(opts.Out, state)
+
+	options := []string{
+		"Continue — use the existing installation as-is",
+		"Start fresh — remove all managed symlinks and manifest",
+		"Back up and start fresh — archive state then reset",
+	}
+
+	p := prompt.New(opts.In, opts.Out)
+	choice, err := p.SelectWithDefault("", options, 0)
+	if err != nil {
+		return ResultNoop, fmt.Errorf("prompt: %w", err)
+	}
+
+	switch choice {
+	case 0:
+		return ResultContinue, ActionContinue()
+	case 1:
+		if err := ActionFresh(opts.ManifestDir, opts.TargetDir); err != nil {
+			return ResultFresh, fmt.Errorf("start fresh: %w", err)
+		}
+		return ResultFresh, nil
+	case 2:
+		backupDir, err := ActionBackupAndFresh(opts.ManifestDir, opts.TargetDir, opts.ConfigPath, opts.HomeDir)
+		if err != nil {
+			return ResultBackupAndFresh, fmt.Errorf("backup and start fresh: %w", err)
+		}
+		fmt.Fprintf(opts.Out, "Backed up to: %s\n", backupDir)
+		return ResultBackupAndFresh, nil
+	default:
+		// Invalid selection or cancelled: default to continue
+		return ResultContinue, ActionContinue()
+	}
+}

--- a/internal/stateguard/guard_test.go
+++ b/internal/stateguard/guard_test.go
@@ -1,0 +1,188 @@
+package stateguard
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaklabco/dot/internal/manifest"
+)
+
+func TestCheck_MarkerExists(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+	require.NoError(t, WriteMarker())
+
+	result, err := Check(context.Background(), GuardOptions{
+		In:          strings.NewReader(""),
+		Out:         &bytes.Buffer{},
+		ManifestDir: t.TempDir(),
+		TargetDir:   t.TempDir(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ResultAlreadyAcknowledged, result)
+}
+
+func TestCheck_NoManifest(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	result, err := Check(context.Background(), GuardOptions{
+		In:          strings.NewReader(""),
+		Out:         &bytes.Buffer{},
+		ManifestDir: t.TempDir(),
+		TargetDir:   t.TempDir(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ResultNoop, result)
+}
+
+func TestCheck_EmptyManifest(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	manifestDir := t.TempDir()
+	writeTestManifest(t, manifestDir, map[string]manifest.PackageInfo{})
+
+	result, err := Check(context.Background(), GuardOptions{
+		In:          strings.NewReader(""),
+		Out:         &bytes.Buffer{},
+		ManifestDir: manifestDir,
+		TargetDir:   t.TempDir(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ResultNoop, result)
+}
+
+func TestCheck_Continue(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	manifestDir := t.TempDir()
+	writeTestManifest(t, manifestDir, map[string]manifest.PackageInfo{
+		"shell": {Links: []string{".bashrc"}, LinkCount: 1},
+	})
+
+	out := &bytes.Buffer{}
+	result, err := Check(context.Background(), GuardOptions{
+		In:          strings.NewReader("1\n"),
+		Out:         out,
+		ManifestDir: manifestDir,
+		TargetDir:   t.TempDir(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ResultContinue, result)
+	assert.True(t, MarkerExists())
+	assert.Contains(t, out.String(), "Existing dot installation detected")
+}
+
+func TestCheck_Fresh(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	targetDir := t.TempDir()
+	manifestDir := t.TempDir()
+
+	// Create a symlink to be cleaned up
+	symlinkPath := filepath.Join(targetDir, ".bashrc")
+	require.NoError(t, os.Symlink("/some/source", symlinkPath))
+
+	writeTestManifest(t, manifestDir, map[string]manifest.PackageInfo{
+		"shell": {
+			Links:     []string{".bashrc"},
+			LinkCount: 1,
+			TargetDir: targetDir,
+		},
+	})
+
+	result, err := Check(context.Background(), GuardOptions{
+		In:          strings.NewReader("2\n"),
+		Out:         &bytes.Buffer{},
+		ManifestDir: manifestDir,
+		TargetDir:   targetDir,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ResultFresh, result)
+	assert.True(t, MarkerExists())
+
+	// Symlink should be removed
+	_, err = os.Lstat(symlinkPath)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestCheck_BackupAndFresh(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	targetDir := t.TempDir()
+	manifestDir := t.TempDir()
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("test"), 0644))
+
+	writeTestManifest(t, manifestDir, map[string]manifest.PackageInfo{
+		"shell": {
+			Links:     []string{".bashrc"},
+			LinkCount: 1,
+			TargetDir: targetDir,
+		},
+	})
+
+	result, err := Check(context.Background(), GuardOptions{
+		In:          strings.NewReader("3\n"),
+		Out:         &bytes.Buffer{},
+		ManifestDir: manifestDir,
+		TargetDir:   targetDir,
+		ConfigPath:  configPath,
+		HomeDir:     t.TempDir(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ResultBackupAndFresh, result)
+	assert.True(t, MarkerExists())
+}
+
+func TestCheck_SkipAutosContinue(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	manifestDir := t.TempDir()
+	writeTestManifest(t, manifestDir, map[string]manifest.PackageInfo{
+		"shell": {Links: []string{".bashrc"}, LinkCount: 1},
+	})
+
+	result, err := Check(context.Background(), GuardOptions{
+		In:          strings.NewReader(""),
+		Out:         &bytes.Buffer{},
+		Skip:        true,
+		ManifestDir: manifestDir,
+		TargetDir:   t.TempDir(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ResultContinue, result)
+	assert.True(t, MarkerExists())
+}
+
+func TestCheck_EmptyInputDefaultsContinue(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	manifestDir := t.TempDir()
+	writeTestManifest(t, manifestDir, map[string]manifest.PackageInfo{
+		"shell": {Links: []string{".bashrc"}, LinkCount: 1},
+	})
+
+	result, err := Check(context.Background(), GuardOptions{
+		In:          strings.NewReader("\n"),
+		Out:         &bytes.Buffer{},
+		ManifestDir: manifestDir,
+		TargetDir:   t.TempDir(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ResultContinue, result)
+	assert.True(t, MarkerExists())
+}

--- a/internal/stateguard/marker.go
+++ b/internal/stateguard/marker.go
@@ -1,0 +1,32 @@
+// Package stateguard detects existing dot state on first run and lets
+// the user choose how to proceed (continue, reset, or back up and reset).
+package stateguard
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/yaklabco/dot/internal/config"
+)
+
+const markerFile = ".dot-acknowledged"
+
+// MarkerPath returns the full path to the acknowledgment marker file.
+func MarkerPath() string {
+	return config.GetXDGStatePath(filepath.Join("dot", markerFile))
+}
+
+// MarkerExists returns true if the acknowledgment marker file exists.
+func MarkerExists() bool {
+	_, err := os.Stat(MarkerPath())
+	return err == nil
+}
+
+// WriteMarker creates the acknowledgment marker file, including parent directories.
+func WriteMarker() error {
+	path := MarkerPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, nil, 0644)
+}

--- a/internal/stateguard/marker_test.go
+++ b/internal/stateguard/marker_test.go
@@ -1,0 +1,67 @@
+package stateguard
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarkerPath_Default(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", "")
+	path := MarkerPath()
+	homeDir, _ := os.UserHomeDir()
+	assert.Equal(t, filepath.Join(homeDir, ".local", "state", "dot", ".dot-acknowledged"), path)
+}
+
+func TestMarkerPath_WithXDGOverride(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", "/tmp/custom-state")
+	path := MarkerPath()
+	assert.Equal(t, "/tmp/custom-state/dot/.dot-acknowledged", path)
+}
+
+func TestMarkerExists_False(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+	assert.False(t, MarkerExists())
+}
+
+func TestMarkerExists_True(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+
+	markerDir := filepath.Join(dir, "dot")
+	require.NoError(t, os.MkdirAll(markerDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(markerDir, ".dot-acknowledged"), nil, 0644))
+
+	assert.True(t, MarkerExists())
+}
+
+func TestWriteMarker(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+
+	assert.False(t, MarkerExists())
+	require.NoError(t, WriteMarker())
+	assert.True(t, MarkerExists())
+}
+
+func TestWriteMarker_CreatesParentDirs(t *testing.T) {
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "deep", "nested")
+	t.Setenv("XDG_STATE_HOME", nested)
+
+	require.NoError(t, WriteMarker())
+	assert.True(t, MarkerExists())
+}
+
+func TestWriteMarker_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+
+	require.NoError(t, WriteMarker())
+	require.NoError(t, WriteMarker())
+	assert.True(t, MarkerExists())
+}

--- a/tests/integration/cli_helpers_test.go
+++ b/tests/integration/cli_helpers_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"os"
 	"os/exec"
 	"testing"
 )
@@ -11,6 +12,17 @@ func skipIfCLIUnavailable(t *testing.T, output []byte, err error) {
 	if err != nil {
 		t.Skipf("CLI execution unavailable in this environment: %v, output: %s", err, output)
 	}
+}
+
+// isolateStateDir sets XDG_STATE_HOME to a temp directory so that
+// subprocess commands don't leak the state guard marker to the real home.
+func isolateStateDir(t *testing.T, cmd *exec.Cmd) {
+	t.Helper()
+	stateDir := t.TempDir()
+	if cmd.Env == nil {
+		cmd.Env = os.Environ()
+	}
+	cmd.Env = append(cmd.Env, "XDG_STATE_HOME="+stateDir)
 }
 
 // checkCLIAvailable verifies the CLI can be executed.

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -77,6 +77,7 @@ func TestCLI_ManageCommand(t *testing.T) {
 	cmd := exec.Command("go", "run", "../../cmd/dot", "manage", "vim",
 		"--package-dir", env.PackageDir,
 		"--target-dir", env.TargetDir)
+	isolateStateDir(t, cmd)
 
 	output, err := cmd.CombinedOutput()
 	skipIfCLIUnavailable(t, output, err)
@@ -109,6 +110,7 @@ func TestCLI_DryRunFlag(t *testing.T) {
 		"--package-dir", env.PackageDir,
 		"--target-dir", env.TargetDir,
 		"--dry-run")
+	isolateStateDir(t, cmd)
 
 	output, err := cmd.CombinedOutput()
 	skipIfCLIUnavailable(t, output, err)
@@ -138,6 +140,7 @@ func TestCLI_VerboseFlag(t *testing.T) {
 		"--package-dir", env.PackageDir,
 		"--target-dir", env.TargetDir,
 		"--verbose")
+	isolateStateDir(t, cmd)
 
 	output, err := cmd.CombinedOutput()
 	skipIfCLIUnavailable(t, output, err)
@@ -214,6 +217,7 @@ func TestCLI_MultiplePackages(t *testing.T) {
 	cmd := exec.Command("go", "run", "../../cmd/dot", "manage", "vim", "zsh",
 		"--package-dir", env.PackageDir,
 		"--target-dir", env.TargetDir)
+	isolateStateDir(t, cmd)
 
 	output, err := cmd.CombinedOutput()
 	skipIfCLIUnavailable(t, output, err)
@@ -460,6 +464,7 @@ func TestCLI_LongRunningOperation(t *testing.T) {
 		"--target-dir", env.TargetDir)
 
 	cmd := exec.Command("go", args...)
+	isolateStateDir(t, cmd)
 	output, err := cmd.CombinedOutput()
 	skipIfCLIUnavailable(t, output, err)
 

--- a/tests/integration/signal_test.go
+++ b/tests/integration/signal_test.go
@@ -122,6 +122,7 @@ func TestSignalHandling(t *testing.T) {
 		cmd := exec.CommandContext(ctx, "go", "run", "../../cmd/dot", "manage", "test-pkg",
 			"--dir", packageDir,
 			"--target", targetDir)
+		isolateStateDir(t, cmd)
 
 		output, err := cmd.CombinedOutput()
 


### PR DESCRIPTION
## Summary

- Detects existing dot state (manifest, packages, symlinks) on first mutating command (`manage`, `adopt`, `clone`)
- Prompts user to continue, start fresh, or back up and start fresh
- Auto-continues in batch mode (`--batch`) and non-TTY sessions
- Writes marker file (`~/.local/state/dot/.dot-acknowledged`) so prompt appears exactly once
- Silent when no existing state is found (true first-run) or marker already exists

## Changes

1. **Export XDG helpers** — `GetXDGStatePath`/`GetXDGDataPath` in `internal/config/extended.go`
2. **Add `SelectWithDefault`** to `internal/cli/prompt/` — returns configurable default on empty input/EOF
3. **New `internal/stateguard/` package** — marker management, action handlers (continue, fresh, backup+fresh), orchestrator
4. **Wire into commands** — `runStateGuard(cmd)` as first call in `runManage`, `runAdoptCommand`, `runClone`

## Test plan

- [x] `go test ./internal/stateguard/... -race -count=1` — 23 tests pass
- [x] `go test ./internal/cli/prompt/... -race -count=1` — all tests pass including new SelectWithDefault
- [x] `go test ./cmd/dot/... -race -count=1` — all tests pass including integration tests
- [x] `go test ./... -race -count=1` — full suite passes, zero regressions
- [ ] Manual: create manifest with packages, run `dot manage` → verify prompt appears and each option works