### PR TITLE
fix(planner): allow directory creation at parents of protected paths

### DIFF
--- a/internal/planner/validate.go
+++ b/internal/planner/validate.go
@@ -46,6 +46,16 @@ func checkPathAgainstProtected(absPath, absProtected string) (insideProtected, o
 	return false, false
 }
 
+// resourceKind identifies the kind of desired-state resource being validated.
+// It gates the parent-override rejection below, so it is a closed enum rather
+// than a free-form string.
+type resourceKind int
+
+const (
+	resourceSymlink resourceKind = iota
+	resourceDirectory
+)
+
 // ValidateNoSelfManagement validates that a package does not attempt to manage
 // dot's own operational directories.
 //
@@ -63,14 +73,14 @@ func ValidateNoSelfManagement(packageName string, desired DesiredState) error {
 
 	// Check all desired links
 	for linkPath := range desired.Links {
-		if err := checkPathConflicts(packageName, linkPath, protectedPaths, "symlinks"); err != nil {
+		if err := checkPathConflicts(packageName, linkPath, protectedPaths, resourceSymlink); err != nil {
 			return err
 		}
 	}
 
 	// Also check directories
 	for dirPath := range desired.Dirs {
-		if err := checkPathConflicts(packageName, dirPath, protectedPaths, "directories"); err != nil {
+		if err := checkPathConflicts(packageName, dirPath, protectedPaths, resourceDirectory); err != nil {
 			return err
 		}
 	}
@@ -79,7 +89,7 @@ func ValidateNoSelfManagement(packageName string, desired DesiredState) error {
 }
 
 // checkPathConflicts checks if a path conflicts with any protected paths.
-func checkPathConflicts(packageName, path string, protectedPaths []string, resourceType string) error {
+func checkPathConflicts(packageName, path string, protectedPaths []string, kind resourceKind) error {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return nil // Skip if we can't resolve path
@@ -94,7 +104,7 @@ func checkPathConflicts(packageName, path string, protectedPaths []string, resou
 		insideProtected, overridesProtected := checkPathAgainstProtected(absPath, absProtected)
 
 		if insideProtected {
-			if resourceType == "symlinks" {
+			if kind == resourceSymlink {
 				return fmt.Errorf(
 					"package %q attempts to create symlinks in dot's operational directory: %s\n"+
 						"Packages cannot manage dot's configuration or data directories.\n"+
@@ -108,7 +118,12 @@ func checkPathConflicts(packageName, path string, protectedPaths []string, resou
 			)
 		}
 
-		if overridesProtected {
+		// A symlink at a parent of a protected path would make the protected
+		// path resolve into package-controlled space, so it stays rejected.
+		// Creating a plain directory at a parent (e.g. ~/.config when
+		// ~/.config/dot is protected) is safe: the protected path continues
+		// to exist inside it untouched.
+		if overridesProtected && kind == resourceSymlink {
 			return fmt.Errorf(
 				"package %q would override dot's operational directory: %s",
 				packageName, protected,

--- a/internal/planner/validate_test.go
+++ b/internal/planner/validate_test.go
@@ -144,6 +144,58 @@ func TestValidateNoSelfManagement_AllowsNeighboringDirectories(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestValidateNoSelfManagement_AllowsParentDirectoryOfProtected(t *testing.T) {
+	homeDir, _ := os.UserHomeDir()
+	xdgConfig := os.Getenv("XDG_CONFIG_HOME")
+	if xdgConfig == "" {
+		xdgConfig = filepath.Join(homeDir, ".config")
+	}
+
+	// XDG-style packages need to create ~/.config itself (a parent of the
+	// protected ~/.config/dot). Creating the directory is safe: the protected
+	// path continues to exist inside it untouched.
+	fishConfig := filepath.Join(xdgConfig, "fish", "config.fish")
+	srcPath := domain.NewFilePath("/packages/fish/.config/fish/config.fish").Unwrap()
+	tgtPath := domain.NewTargetPath(fishConfig).Unwrap()
+
+	desired := DesiredState{
+		Links: map[string]LinkSpec{
+			fishConfig: {Source: srcPath, Target: tgtPath},
+		},
+		Dirs: map[string]DirSpec{
+			xdgConfig:                        {},
+			filepath.Join(xdgConfig, "fish"): {},
+		},
+	}
+
+	err := ValidateNoSelfManagement("fish", desired)
+	assert.NoError(t, err)
+}
+
+func TestValidateNoSelfManagement_RejectsSymlinkReplacingParentOfProtected(t *testing.T) {
+	homeDir, _ := os.UserHomeDir()
+	xdgConfig := os.Getenv("XDG_CONFIG_HOME")
+	if xdgConfig == "" {
+		xdgConfig = filepath.Join(homeDir, ".config")
+	}
+
+	// A symlink AT ~/.config would make the protected ~/.config/dot resolve
+	// into package-controlled space. That must stay rejected.
+	srcPath := domain.NewFilePath("/packages/evil/.config").Unwrap()
+	tgtPath := domain.NewTargetPath(xdgConfig).Unwrap()
+
+	desired := DesiredState{
+		Links: map[string]LinkSpec{
+			xdgConfig: {Source: srcPath, Target: tgtPath},
+		},
+		Dirs: map[string]DirSpec{},
+	}
+
+	err := ValidateNoSelfManagement("evil", desired)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "would override")
+}
+
 func TestValidateNoSelfManagement_EmptyDesiredState(t *testing.T) {
 	desired := DesiredState{
 		Links: map[string]LinkSpec{},


### PR DESCRIPTION
With package_name_mapping=false, XDG-style packages (e.g. fish -> ~/.config/fish) plan a directory create at ~/.config, which is a parent of the protected ~/.config/dot. The overridesProtected rejection now applies only to symlinks, which genuinely would redirect the protected path into package-controlled space. Directory creation at a parent is inert (MkdirAll semantics). Includes an adversarial regression test for the symlink-at-parent case and converts the resource kind to a typed enum since it now gates the protection.