### PR TITLE
fix(manage): register pre-existing correct links in the manifest

### DIFF
--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -68,6 +68,21 @@ type Plan struct {
 	// allowing accurate manifest updates and selective operations.
 	// Optional field for backward compatibility.
 	PackageOperations map[string][]OperationID `json:"package_operations,omitempty"`
+
+	// PackageSkippedLinks maps package names to absolute target paths of links
+	// that already exist on disk pointing at the correct source. They generate
+	// no operations but are part of the managed state and must be recorded in
+	// the manifest alongside newly created links.
+	PackageSkippedLinks map[string][]string `json:"package_skipped_links,omitempty"`
+}
+
+// SkippedLinksForPackage returns the already-correct link target paths for the
+// specified package. Returns nil when none were recorded.
+func (p Plan) SkippedLinksForPackage(pkg string) []string {
+	if p.PackageSkippedLinks == nil {
+		return nil
+	}
+	return p.PackageSkippedLinks[pkg]
 }
 
 // Validate checks if the plan is valid.

--- a/internal/pipeline/packages.go
+++ b/internal/pipeline/packages.go
@@ -142,10 +142,37 @@ func (p *ManagePipeline) Execute(ctx context.Context, input ManageInput) domain.
 			Conflicts:      nil, // No conflicts in success path
 			Warnings:       convertWarnings(resolved.Warnings),
 		},
-		PackageOperations: packageOps,
+		PackageOperations:   packageOps,
+		PackageSkippedLinks: buildPackageSkippedLinks(packages, resolved.Skipped),
 	}
 
 	return domain.Ok(plan)
+}
+
+// buildPackageSkippedLinks maps package names to the target paths of link
+// creations that were skipped because the correct symlink already exists.
+// Returns nil when nothing was skipped so the plan field stays omitted.
+func buildPackageSkippedLinks(packages []domain.Package, skipped []domain.Operation) map[string][]string {
+	if len(skipped) == 0 {
+		return nil
+	}
+	result := make(map[string][]string)
+	for _, op := range skipped {
+		linkOp, ok := op.(domain.LinkCreate)
+		if !ok {
+			continue
+		}
+		for _, pkg := range packages {
+			if isUnderPath(linkOp.Source.String(), pkg.Path.String()) {
+				result[pkg.Name] = append(result[pkg.Name], linkOp.Target.String())
+				break
+			}
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }
 
 // countOperationsByKind counts operations of a specific kind

--- a/internal/planner/resolver.go
+++ b/internal/planner/resolver.go
@@ -160,6 +160,7 @@ type ResolutionOutcome struct {
 	Operations []domain.Operation // Modified operations after resolution
 	Conflict   *Conflict          // If status is ResolveConflict
 	Warning    *Warning           // If status is ResolveWarning
+	Skipped    []domain.Operation // Operations whose desired effect already exists on disk
 }
 
 // ResolveResult contains all resolved operations, conflicts, and warnings
@@ -167,6 +168,10 @@ type ResolveResult struct {
 	Operations []domain.Operation
 	Conflicts  []Conflict
 	Warnings   []Warning
+	// Skipped holds operations that were not emitted because their desired
+	// effect already exists on disk (e.g. a symlink that already points at
+	// the correct source). They carry no work but still describe managed state.
+	Skipped []domain.Operation
 }
 
 // NewResolveResult creates a new ResolveResult with the given operations
@@ -178,6 +183,7 @@ func NewResolveResult(ops []domain.Operation) ResolveResult {
 		Operations: ops,
 		Conflicts:  []Conflict{},
 		Warnings:   []Warning{},
+		Skipped:    []domain.Operation{},
 	}
 }
 
@@ -239,9 +245,11 @@ func detectLinkCreateConflicts(op domain.LinkCreate, current CurrentState) Resol
 	// Check if symlink already exists and points to the correct location
 	if link, exists := current.Links[targetKey]; exists {
 		if link.Target == op.Source.String() {
-			// Link already correct, skip
+			// Link already correct: no operation needed, but the link is part of
+			// the desired state and must still be recorded in the manifest.
 			return ResolutionOutcome{
-				Status: ResolveSkip,
+				Status:  ResolveSkip,
+				Skipped: []domain.Operation{op},
 			}
 		}
 		// Symlink exists but points elsewhere
@@ -492,6 +500,7 @@ func Resolve(
 			}
 
 		case ResolveSkip:
+			result.Skipped = append(result.Skipped, outcome.Skipped...)
 			if outcome.Warning != nil {
 				result = result.WithWarning(*outcome.Warning)
 			}

--- a/pkg/dot/manage_registration_test.go
+++ b/pkg/dot/manage_registration_test.go
@@ -1,0 +1,190 @@
+package dot
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklabco/dot/internal/adapters"
+	"github.com/yaklabco/dot/internal/executor"
+	"github.com/yaklabco/dot/internal/ignore"
+	"github.com/yaklabco/dot/internal/manifest"
+	"github.com/yaklabco/dot/internal/pipeline"
+	"github.com/yaklabco/dot/internal/planner"
+)
+
+// registrationTestEnv bundles the services needed to exercise manage and
+// remanage against a MemFS with a two-file package.
+type registrationTestEnv struct {
+	fs          *adapters.MemFS
+	svc         *ManageService
+	manifestSvc *ManifestService
+	managePipe  *pipeline.ManagePipeline
+	exec        *executor.Executor
+	unmanageSvc *UnmanageService
+	packageDir  string
+	targetDir   string
+}
+
+func newRegistrationTestEnv(t *testing.T) *registrationTestEnv {
+	t.Helper()
+	fs := adapters.NewMemFS()
+	ctx := context.Background()
+	packageDir := "/test/packages"
+	targetDir := "/test/target"
+
+	require.NoError(t, fs.MkdirAll(ctx, packageDir+"/test-pkg", 0o755))
+	require.NoError(t, fs.MkdirAll(ctx, targetDir, 0o755))
+	require.NoError(t, fs.WriteFile(ctx, packageDir+"/test-pkg/dot-vimrc", []byte("vim"), 0o644))
+	require.NoError(t, fs.WriteFile(ctx, packageDir+"/test-pkg/dot-bashrc", []byte("bash"), 0o644))
+
+	managePipe := pipeline.NewManagePipeline(pipeline.ManagePipelineOpts{
+		FS:                 fs,
+		IgnoreSet:          ignore.NewDefaultIgnoreSet(),
+		Policies:           planner.ResolutionPolicies{OnFileExists: planner.PolicyFail},
+		PackageNameMapping: false,
+	})
+	exec := executor.New(executor.Opts{
+		FS:     fs,
+		Logger: adapters.NewNoopLogger(),
+		Tracer: adapters.NewNoopTracer(),
+	})
+	manifestStore := manifest.NewFSManifestStore(fs)
+	manifestSvc := newManifestService(fs, adapters.NewNoopLogger(), manifestStore)
+	unmanageSvc := newUnmanageService(fs, adapters.NewNoopLogger(), exec, manifestSvc, packageDir, targetDir, false)
+	svc := newManageService(fs, adapters.NewNoopLogger(), managePipe, exec, manifestSvc, unmanageSvc, packageDir, targetDir, false)
+
+	return &registrationTestEnv{
+		fs:          fs,
+		svc:         svc,
+		manifestSvc: manifestSvc,
+		managePipe:  managePipe,
+		exec:        exec,
+		unmanageSvc: unmanageSvc,
+		packageDir:  packageDir,
+		targetDir:   targetDir,
+	}
+}
+
+// manifestLinks loads the manifest and returns the recorded links for test-pkg.
+func (e *registrationTestEnv) manifestLinks(t *testing.T) []string {
+	t.Helper()
+	ctx := context.Background()
+	targetPath := NewTargetPath(e.targetDir).Unwrap()
+	result := e.manifestSvc.Load(ctx, targetPath)
+	require.True(t, result.IsOk(), "manifest must load")
+	m := result.Unwrap()
+	pkg, exists := m.GetPackage("test-pkg")
+	require.True(t, exists, "test-pkg must be in manifest")
+	return pkg.Links
+}
+
+// seedManifest writes a manifest entry for test-pkg with the given links and
+// a current content hash, simulating a stale manifest that predates some links.
+func (e *registrationTestEnv) seedManifest(t *testing.T, links []string) {
+	t.Helper()
+	ctx := context.Background()
+	targetPath := NewTargetPath(e.targetDir).Unwrap()
+	m := manifest.New()
+	m.AddPackage(manifest.PackageInfo{
+		Name:        "test-pkg",
+		InstalledAt: time.Now(),
+		LinkCount:   len(links),
+		Links:       links,
+		Source:      manifest.SourceManaged,
+		TargetDir:   e.targetDir,
+		PackageDir:  e.packageDir + "/test-pkg",
+	})
+	hasher := manifest.NewContentHasher(e.fs)
+	pkgPath := NewPackagePath(e.packageDir + "/test-pkg").Unwrap()
+	hash, err := hasher.HashPackage(ctx, pkgPath)
+	require.NoError(t, err)
+	m.SetHash("test-pkg", hash)
+	require.NoError(t, e.manifestSvc.Save(ctx, targetPath, m))
+}
+
+func TestManage_RecordsPreExistingCorrectLinks(t *testing.T) {
+	env := newRegistrationTestEnv(t)
+	ctx := context.Background()
+
+	// One link already exists and points at the correct package file.
+	require.NoError(t, env.fs.Symlink(ctx, env.packageDir+"/test-pkg/dot-bashrc", env.targetDir+"/.bashrc"))
+
+	require.NoError(t, env.svc.Manage(ctx, "test-pkg"))
+
+	assert.ElementsMatch(t, []string{".vimrc", ".bashrc"}, env.manifestLinks(t),
+		"manifest must record the pre-existing correct link, not only the newly created one")
+}
+
+func TestManage_HealsManifestMissingLinksWhenAllLinksExist(t *testing.T) {
+	env := newRegistrationTestEnv(t)
+	ctx := context.Background()
+
+	// Both links exist correctly on disk.
+	require.NoError(t, env.fs.Symlink(ctx, env.packageDir+"/test-pkg/dot-vimrc", env.targetDir+"/.vimrc"))
+	require.NoError(t, env.fs.Symlink(ctx, env.packageDir+"/test-pkg/dot-bashrc", env.targetDir+"/.bashrc"))
+
+	// Manifest predates .bashrc: only .vimrc recorded.
+	env.seedManifest(t, []string{".vimrc"})
+
+	err := env.svc.Manage(ctx, "test-pkg")
+	require.NoError(t, err, "healing the manifest is a change, not a no-op")
+
+	assert.ElementsMatch(t, []string{".vimrc", ".bashrc"}, env.manifestLinks(t),
+		"manage must adopt already-correct links into the manifest")
+}
+
+func TestRemanage_RecreatesLinkMissingFromDiskAndManifest(t *testing.T) {
+	env := newRegistrationTestEnv(t)
+	ctx := context.Background()
+
+	// Only .vimrc is linked and recorded; .bashrc is neither on disk nor in the
+	// manifest, and the stored package hash matches current content, so the
+	// incremental fast path would previously report "no changes".
+	require.NoError(t, env.fs.Symlink(ctx, env.packageDir+"/test-pkg/dot-vimrc", env.targetDir+"/.vimrc"))
+	env.seedManifest(t, []string{".vimrc"})
+
+	require.NoError(t, env.svc.Remanage(ctx, "test-pkg"))
+
+	isLink, err := env.fs.IsSymlink(ctx, env.targetDir+"/.bashrc")
+	require.NoError(t, err)
+	assert.True(t, isLink, "remanage must recreate the missing link")
+	assert.ElementsMatch(t, []string{".vimrc", ".bashrc"}, env.manifestLinks(t))
+}
+
+func TestRemanage_HealsManifestMissingLinksWhenAllLinksExist(t *testing.T) {
+	env := newRegistrationTestEnv(t)
+	ctx := context.Background()
+
+	require.NoError(t, env.fs.Symlink(ctx, env.packageDir+"/test-pkg/dot-vimrc", env.targetDir+"/.vimrc"))
+	require.NoError(t, env.fs.Symlink(ctx, env.packageDir+"/test-pkg/dot-bashrc", env.targetDir+"/.bashrc"))
+	env.seedManifest(t, []string{".vimrc"})
+
+	err := env.svc.Remanage(ctx, "test-pkg")
+	require.NoError(t, err, "healing the manifest is a change, not a no-op")
+
+	assert.ElementsMatch(t, []string{".vimrc", ".bashrc"}, env.manifestLinks(t),
+		"remanage must adopt already-correct links into the manifest")
+}
+
+func TestManage_DryRunDoesNotReconcileManifest(t *testing.T) {
+	env := newRegistrationTestEnv(t)
+	ctx := context.Background()
+
+	// All links exist correctly on disk but the package is not in the manifest.
+	require.NoError(t, env.fs.Symlink(ctx, env.packageDir+"/test-pkg/dot-vimrc", env.targetDir+"/.vimrc"))
+	require.NoError(t, env.fs.Symlink(ctx, env.packageDir+"/test-pkg/dot-bashrc", env.targetDir+"/.bashrc"))
+
+	dryService := newManageService(env.fs, adapters.NewNoopLogger(), env.managePipe, env.exec, env.manifestSvc, env.unmanageSvc, env.packageDir, env.targetDir, true)
+
+	_ = dryService.Manage(ctx, "test-pkg")
+
+	targetPath := NewTargetPath(env.targetDir).Unwrap()
+	result := env.manifestSvc.Load(ctx, targetPath)
+	require.True(t, result.IsOk())
+	m := result.Unwrap()
+	_, exists := m.GetPackage("test-pkg")
+	assert.False(t, exists, "dry-run must not write manifest reconciliation")
+}

--- a/pkg/dot/manage_service.go
+++ b/pkg/dot/manage_service.go
@@ -74,22 +74,7 @@ func (s *ManageService) Manage(ctx context.Context, packages ...string) error {
 	// A corrupt manifest could cause the pipeline to produce zero operations
 	// (symlinks exist on disk but manifest is unreadable), masking data integrity issues.
 	if len(plan.Operations) == 0 {
-		if err := s.validateManifestReadable(ctx); err != nil {
-			return err
-		}
-
-		// Reconciliation: if symlinks exist on disk but the package is not in the manifest
-		// (e.g., after manifest loss), re-register the package.
-		reconciled, err := s.reconcileManifest(ctx, packages, plan)
-		if err != nil {
-			return err
-		}
-		if reconciled {
-			return nil
-		}
-
-		s.logger.Info(ctx, "no_operations_required", "packages", packages)
-		return ErrNoChanges{Packages: packages}
+		return s.manageZeroOperations(ctx, packages, plan)
 	}
 
 	if s.dryRun {
@@ -112,6 +97,42 @@ func (s *ManageService) Manage(ctx context.Context, packages ...string) error {
 		return fmt.Errorf("manifest update failed: %w", err)
 	}
 	return nil
+}
+
+// manageZeroOperations handles a manage whose plan produced no operations.
+// It validates the manifest, then reconciles it against reality: packages
+// missing entirely are re-registered from a disk scan, and already-correct
+// links the manifest does not record are adopted from the plan's skipped set.
+func (s *ManageService) manageZeroOperations(ctx context.Context, packages []string, plan Plan) error {
+	if err := s.validateManifestReadable(ctx); err != nil {
+		return err
+	}
+
+	// Reconciliation must not persist anything during a dry run.
+	reconciled := false
+	if !s.dryRun {
+		// If symlinks exist on disk but the package is not in the manifest
+		// (e.g., after manifest loss), re-register the package.
+		var err error
+		reconciled, err = s.reconcileManifest(ctx, packages, plan)
+		if err != nil {
+			return err
+		}
+
+		// Links that already exist correctly generate no operations; if the
+		// manifest does not record them yet, adopt them now.
+		adopted, err := s.reconcileSkippedLinks(ctx, packages, plan)
+		if err != nil {
+			return err
+		}
+		reconciled = reconciled || adopted
+	}
+	if reconciled {
+		return nil
+	}
+
+	s.logger.Info(ctx, "no_operations_required", "packages", packages)
+	return ErrNoChanges{Packages: packages}
 }
 
 // checkPlanConflicts returns an error if the plan contains conflicts.
@@ -194,13 +215,55 @@ func (s *ManageService) Remanage(ctx context.Context, packages ...string) error 
 		return err
 	}
 	if len(plan.Operations) == 0 {
-		s.logger.Info(ctx, "no_changes_detected", "packages", packages)
-		return ErrNoChanges{Packages: packages}
+		return s.remanageZeroOperations(ctx, packages)
 	}
 	if s.dryRun {
 		s.logger.Info(ctx, "dry_run_plan", "operations", len(plan.Operations))
 		return nil
 	}
+	return s.executeAndRecordRemanage(ctx, packages, plan)
+}
+
+// remanageZeroOperations handles a remanage whose incremental plan produced no
+// operations. The incremental fast path only verifies links recorded in the
+// manifest, so it cannot see desired links that were never registered. Re-plan
+// via the manage pipeline: any missing links are created, and links that
+// already exist correctly are adopted into the manifest.
+func (s *ManageService) remanageZeroOperations(ctx context.Context, packages []string) error {
+	managePlan, err := s.PlanManage(ctx, packages...)
+	if err != nil {
+		return err
+	}
+	if err := checkPlanConflicts(managePlan); err != nil {
+		return err
+	}
+
+	if len(managePlan.Operations) > 0 {
+		if s.dryRun {
+			s.logger.Info(ctx, "dry_run_plan", "operations", len(managePlan.Operations))
+			return nil
+		}
+		s.logger.Info(ctx, "unregistered_links_detected", "packages", packages)
+		return s.executeAndRecordRemanage(ctx, packages, managePlan)
+	}
+
+	if !s.dryRun {
+		adopted, err := s.reconcileSkippedLinks(ctx, packages, managePlan)
+		if err != nil {
+			return err
+		}
+		if adopted {
+			return nil
+		}
+	}
+
+	s.logger.Info(ctx, "no_changes_detected", "packages", packages)
+	return ErrNoChanges{Packages: packages}
+}
+
+// executeAndRecordRemanage executes a plan and updates the manifest for each
+// package, preserving the package's existing source type.
+func (s *ManageService) executeAndRecordRemanage(ctx context.Context, packages []string, plan Plan) error {
 	result := s.executor.Execute(ctx, plan)
 	if !result.IsOk() {
 		return result.UnwrapErr()
@@ -232,6 +295,61 @@ func (s *ManageService) Remanage(ctx context.Context, packages ...string) error 
 	return nil
 }
 
+// reconcileSkippedLinks updates the manifest for packages whose plan skipped
+// already-correct links that the manifest does not record yet. Returns true
+// if any package's manifest entry was updated.
+func (s *ManageService) reconcileSkippedLinks(ctx context.Context, packages []string, plan Plan) (bool, error) {
+	targetPathResult := NewTargetPath(s.targetDir)
+	if !targetPathResult.IsOk() {
+		return false, targetPathResult.UnwrapErr()
+	}
+	targetPath := targetPathResult.Unwrap()
+
+	manifestResult := s.manifestSvc.Load(ctx, targetPath)
+	if !manifestResult.IsOk() {
+		return false, manifestResult.UnwrapErr()
+	}
+	m := manifestResult.Unwrap()
+
+	updated := false
+	for _, pkg := range packages {
+		skipped := plan.SkippedLinksForPackage(pkg)
+		if len(skipped) == 0 {
+			continue
+		}
+		pkgInfo, exists := m.GetPackage(pkg)
+		if !exists {
+			// Whole-package registration is handled by reconcileManifest.
+			continue
+		}
+		recorded := make(map[string]struct{}, len(pkgInfo.Links))
+		for _, link := range pkgInfo.Links {
+			recorded[link] = struct{}{}
+		}
+		missing := false
+		for _, abs := range skipped {
+			rel, err := filepath.Rel(s.targetDir, abs)
+			if err != nil {
+				rel = abs
+			}
+			if _, ok := recorded[rel]; !ok {
+				missing = true
+				break
+			}
+		}
+		if !missing {
+			continue
+		}
+		source := pkgInfo.Source
+		if err := s.manifestSvc.UpdateWithSource(ctx, targetPath, s.packageDir, []string{pkg}, plan, source); err != nil {
+			return false, fmt.Errorf("manifest reconciliation failed for %s: %w", pkg, err)
+		}
+		s.logger.Info(ctx, "adopted_existing_links_into_manifest", "package", pkg)
+		updated = true
+	}
+	return updated, nil
+}
+
 // PlanRemanage computes incremental execution plan using hash-based change detection.
 func (s *ManageService) PlanRemanage(ctx context.Context, packages ...string) (Plan, error) {
 	targetPathResult := NewTargetPath(s.targetDir)
@@ -251,9 +369,10 @@ func (s *ManageService) PlanRemanage(ctx context.Context, packages ...string) (P
 	hasher := manifest.NewContentHasher(s.fs)
 	allOperations := make([]Operation, 0)
 	packageOps := make(map[string][]OperationID)
+	skippedLinks := make(map[string][]string)
 
 	for _, pkg := range packages {
-		ops, pkgOpsMap, err := s.planSinglePackageRemanage(ctx, pkg, &m, hasher)
+		ops, pkgOpsMap, pkgSkipped, err := s.planSinglePackageRemanage(ctx, pkg, &m, hasher)
 		if err != nil {
 			return Plan{}, err
 		}
@@ -261,6 +380,13 @@ func (s *ManageService) PlanRemanage(ctx context.Context, packages ...string) (P
 		for k, v := range pkgOpsMap {
 			packageOps[k] = v
 		}
+		for k, v := range pkgSkipped {
+			skippedLinks[k] = append(skippedLinks[k], v...)
+		}
+	}
+
+	if len(skippedLinks) == 0 {
+		skippedLinks = nil
 	}
 
 	return Plan{
@@ -269,7 +395,8 @@ func (s *ManageService) PlanRemanage(ctx context.Context, packages ...string) (P
 			PackageCount:   len(packages),
 			OperationCount: len(allOperations),
 		},
-		PackageOperations: packageOps,
+		PackageOperations:   packageOps,
+		PackageSkippedLinks: skippedLinks,
 	}, nil
 }
 
@@ -279,7 +406,7 @@ func (s *ManageService) planSinglePackageRemanage(
 	pkg string,
 	m *manifest.Manifest,
 	hasher *manifest.ContentHasher,
-) ([]Operation, map[string][]OperationID, error) {
+) ([]Operation, map[string][]OperationID, map[string][]string, error) {
 	_, exists := m.GetPackage(pkg)
 	if !exists {
 		return s.planNewPackageInstall(ctx, pkg)
@@ -287,7 +414,7 @@ func (s *ManageService) planSinglePackageRemanage(
 
 	pkgPath, err := s.getPackagePath(pkg)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	currentHash, err := hasher.HashPackage(ctx, pkgPath)
 	if err != nil {
@@ -311,14 +438,14 @@ func (s *ManageService) planSinglePackageRemanage(
 	}
 
 	s.logger.Info(ctx, "package_unchanged", "package", pkg)
-	return []Operation{}, map[string][]OperationID{}, nil
+	return []Operation{}, map[string][]OperationID{}, nil, nil
 }
 
 // planNewPackageInstall plans installation of a package not yet in manifest.
-func (s *ManageService) planNewPackageInstall(ctx context.Context, pkg string) ([]Operation, map[string][]OperationID, error) {
+func (s *ManageService) planNewPackageInstall(ctx context.Context, pkg string) ([]Operation, map[string][]OperationID, map[string][]string, error) {
 	pkgPlan, err := s.PlanManage(ctx, pkg)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	packageOps := make(map[string][]OperationID)
 	if pkgPlan.PackageOperations != nil {
@@ -326,15 +453,15 @@ func (s *ManageService) planNewPackageInstall(ctx context.Context, pkg string) (
 			packageOps[pkg] = pkgOps
 		}
 	}
-	return pkgPlan.Operations, packageOps, nil
+	return pkgPlan.Operations, packageOps, pkgPlan.PackageSkippedLinks, nil
 }
 
 // planFullRemanage plans full unmanage + manage for a package.
-func (s *ManageService) planFullRemanage(ctx context.Context, pkg string) ([]Operation, map[string][]OperationID, error) {
+func (s *ManageService) planFullRemanage(ctx context.Context, pkg string) ([]Operation, map[string][]OperationID, map[string][]string, error) {
 	// Check if this is an adopted package
 	targetPathResult := NewTargetPath(s.targetDir)
 	if !targetPathResult.IsOk() {
-		return nil, nil, targetPathResult.UnwrapErr()
+		return nil, nil, nil, targetPathResult.UnwrapErr()
 	}
 
 	manifestResult := s.manifestSvc.Load(ctx, targetPathResult.Unwrap())
@@ -355,19 +482,19 @@ func (s *ManageService) planFullRemanage(ctx context.Context, pkg string) ([]Ope
 	// Get unmanage operations first
 	unmanagePlan, err := s.unmanageSvc.PlanUnmanage(ctx, pkg)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// Remove existing symlinks before planning manage operations.
 	// This prevents the scanner from skipping recreation of links that will be deleted.
 	if err := s.removeSymlinksOnly(ctx, unmanagePlan.Operations, s.dryRun); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// Get manage operations (scanner will now not see the old symlinks)
 	managePlan, err := s.PlanManage(ctx, pkg)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// Concatenate operations (unmanage first, then manage)
@@ -384,17 +511,17 @@ func (s *ManageService) planFullRemanage(ctx context.Context, pkg string) ([]Ope
 	mergedOps = append(mergedOps, manageOps...)
 	packageOps[pkg] = mergedOps
 
-	return ops, packageOps, nil
+	return ops, packageOps, managePlan.PackageSkippedLinks, nil
 }
 
 // planAdoptedPackageRemanage plans remanage for an adopted package.
 // Instead of pointing to the package root directory (which breaks single-file
 // packages), it deletes existing links and re-runs the normal manage pipeline
 // to create correct file-level symlinks.
-func (s *ManageService) planAdoptedPackageRemanage(ctx context.Context, pkg string, m manifest.Manifest) ([]Operation, map[string][]OperationID, error) {
+func (s *ManageService) planAdoptedPackageRemanage(ctx context.Context, pkg string, m manifest.Manifest) ([]Operation, map[string][]OperationID, map[string][]string, error) {
 	pkgInfo, exists := m.GetPackage(pkg)
 	if !exists {
-		return nil, nil, fmt.Errorf("package %s not found in manifest", pkg)
+		return nil, nil, nil, fmt.Errorf("package %s not found in manifest", pkg)
 	}
 
 	// Delete existing symlinks
@@ -413,13 +540,13 @@ func (s *ManageService) planAdoptedPackageRemanage(ctx context.Context, pkg stri
 
 	// Remove existing symlinks so the manage pipeline sees a clean target.
 	if err := s.removeSymlinksOnly(ctx, ops, s.dryRun); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// Re-run the normal manage pipeline to create file-level symlinks
 	managePlan, err := s.PlanManage(ctx, pkg)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	ops = append(ops, managePlan.Operations...)
@@ -428,7 +555,7 @@ func (s *ManageService) planAdoptedPackageRemanage(ctx context.Context, pkg stri
 	}
 
 	packageOps := map[string][]OperationID{pkg: opIDs}
-	return ops, packageOps, nil
+	return ops, packageOps, managePlan.PackageSkippedLinks, nil
 }
 
 // getPackagePath constructs and validates package path.

--- a/pkg/dot/manifest_service.go
+++ b/pkg/dot/manifest_service.go
@@ -66,6 +66,10 @@ func (s *ManifestService) UpdateWithSource(ctx context.Context, targetPath Targe
 		deletedLinks := s.extractDeletedLinksFromOperations(ops, targetPath.String())
 		backups := s.extractBackupsFromOperations(ops)
 
+		// Links that already existed correctly produce no operations but are
+		// part of the managed state; record them alongside created links.
+		newLinks = append(newLinks, s.relativeLinkPaths(plan.SkippedLinksForPackage(pkg), targetPath.String())...)
+
 		// Merge with existing links: start from existing, remove deleted, add new
 		links := s.mergeLinks(m, pkg, newLinks, deletedLinks)
 
@@ -130,6 +134,23 @@ func (s *ManifestService) extractLinksFromOperations(ops []Operation, targetDir 
 			}
 			links = append(links, relPath)
 		}
+	}
+	return links
+}
+
+// relativeLinkPaths converts absolute target link paths to paths relative to
+// the target directory, matching the manifest's link representation.
+func (s *ManifestService) relativeLinkPaths(paths []string, targetDir string) []string {
+	if len(paths) == 0 {
+		return nil
+	}
+	links := make([]string, 0, len(paths))
+	for _, p := range paths {
+		relPath, err := filepath.Rel(targetDir, p)
+		if err != nil {
+			relPath = p
+		}
+		links = append(links, relPath)
 	}
 	return links
 }


### PR DESCRIPTION
Fixes #66.

Links that already exist and point at the correct package file were resolved as skips and dropped from the plan, so the manifest never recorded them. Doctor then permanently reported them as unmanaged orphans, and remanage could neither heal the manifest nor recreate such links once deleted (its link verification only checks recorded links).

- Conflict resolver keeps skipped-because-already-correct LinkCreate operations (`ResolveResult.Skipped`); policy-based skips are deliberately not included.
- Pipeline attributes them per package into a new `Plan.PackageSkippedLinks` field.
- Manifest updates merge skipped links alongside created links.
- Zero-operation `manage` adopts unrecorded already-correct links into the manifest; zero-operation `remanage` re-plans via the manage pipeline, so missing desired links are recreated and unrecorded ones adopted.
- Dry-run no longer performs any manifest reconciliation writes (previously `reconcileManifest` wrote during `--dry-run`).
- `reconcileSkippedLinks` propagates target-path and manifest-load errors instead of swallowing them.

Reproduced originally on two machines (tide fish conf.d links invisible to the manifest through repeated `remanage`). Five new tests drive the real pipeline and executor over MemFS covering: recording pre-existing links on manage, manifest healing on manage and remanage, recreating a link missing from both disk and manifest, and dry-run not writing. Full suite green under -race; golangci-lint 0 issues.