### PR TITLE
feat(doctor): non-interactive ignore management and nix pattern category

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,12 @@ dot doctor -v
 
 # JSON output for scripting
 dot doctor --format json
+
+# Manage the orphan ignore list without interactive triage
+dot doctor ignore .nix-profile --reason "nix managed"
+dot doctor ignore --pattern "Code/*"
+dot doctor unignore --pattern "Code/*"
+dot doctor ignores
 ```
 
 Exit codes:

--- a/cmd/dot/doctor.go
+++ b/cmd/dot/doctor.go
@@ -129,6 +129,7 @@ func storeDoctorStatus(cmd *cobra.Command, report dot.DiagnosticReport) {
 // newDoctorCommand creates the doctor command with configuration from global flags.
 func newDoctorCommand() *cobra.Command {
 	cmd := NewDoctorCommand(&dot.Config{})
+	cmd.AddCommand(newDoctorIgnoreCommand(), newDoctorUnignoreCommand(), newDoctorIgnoresCommand())
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		cfg, err := buildConfigWithCmd(cmd)

--- a/cmd/dot/doctor_ignore.go
+++ b/cmd/dot/doctor_ignore.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/yaklabco/dot/pkg/dot"
+)
+
+// newDoctorIgnoreCommand creates the `doctor ignore` subcommand.
+func newDoctorIgnoreCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ignore [PATH]",
+		Short: "Add a symlink path or glob pattern to the doctor ignore list",
+		Long: `Add an entry to the doctor ignore list without interactive triage.
+
+Ignored links and patterns are excluded from orphan detection in future
+doctor runs. Pass a target-relative symlink path, or --pattern with a glob
+matching target-relative paths.
+
+Examples:
+  # Ignore a single foreign symlink
+  dot doctor ignore .nix-profile --reason "nix managed"
+
+  # Ignore everything under a directory
+  dot doctor ignore --pattern "Code/*"`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pattern, _ := cmd.Flags().GetString("pattern")
+			reason, _ := cmd.Flags().GetString("reason")
+
+			if err := validatePathPatternExclusive(args, pattern); err != nil {
+				return err
+			}
+
+			client, err := newDoctorIgnoreClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			if pattern != "" {
+				if err := client.DoctorIgnorePattern(cmd.Context(), pattern); err != nil {
+					return formatError(err)
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "Added ignore pattern: %s\n", pattern)
+				return nil
+			}
+
+			if err := client.DoctorIgnoreLink(cmd.Context(), args[0], reason); err != nil {
+				return formatError(err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Ignored link: %s\n", args[0])
+			return nil
+		},
+	}
+
+	cmd.Flags().String("pattern", "", "Glob pattern to ignore (mutually exclusive with PATH)")
+	cmd.Flags().String("reason", "", "Reason for ignoring (recorded in the manifest)")
+	return cmd
+}
+
+// newDoctorUnignoreCommand creates the `doctor unignore` subcommand.
+func newDoctorUnignoreCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unignore [PATH]",
+		Short: "Remove a symlink path or glob pattern from the doctor ignore list",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pattern, _ := cmd.Flags().GetString("pattern")
+
+			if err := validatePathPatternExclusive(args, pattern); err != nil {
+				return err
+			}
+
+			client, err := newDoctorIgnoreClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			if pattern != "" {
+				if err := client.DoctorUnignorePattern(cmd.Context(), pattern); err != nil {
+					return formatError(err)
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "Removed ignore pattern: %s\n", pattern)
+				return nil
+			}
+
+			if err := client.DoctorUnignoreLink(cmd.Context(), args[0]); err != nil {
+				return formatError(err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Unignored link: %s\n", args[0])
+			return nil
+		},
+	}
+
+	cmd.Flags().String("pattern", "", "Glob pattern to remove (mutually exclusive with PATH)")
+	return cmd
+}
+
+// newDoctorIgnoresCommand creates the `doctor ignores` subcommand.
+func newDoctorIgnoresCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "ignores",
+		Short: "List the doctor ignore list",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newDoctorIgnoreClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			links, patterns, err := client.DoctorListIgnored(cmd.Context())
+			if err != nil {
+				return formatError(err)
+			}
+
+			out := cmd.OutOrStdout()
+			if len(links) == 0 && len(patterns) == 0 {
+				fmt.Fprintln(out, "No ignored links or patterns")
+				return nil
+			}
+
+			if len(patterns) > 0 {
+				fmt.Fprintln(out, "Ignored patterns:")
+				sorted := append([]string(nil), patterns...)
+				sort.Strings(sorted)
+				for _, p := range sorted {
+					fmt.Fprintf(out, "  %s\n", p)
+				}
+			}
+
+			if len(links) > 0 {
+				fmt.Fprintln(out, "Ignored links:")
+				paths := make([]string, 0, len(links))
+				for path := range links {
+					paths = append(paths, path)
+				}
+				sort.Strings(paths)
+				for _, path := range paths {
+					link := links[path]
+					if link.Reason != "" {
+						fmt.Fprintf(out, "  %s -> %s (%s)\n", path, link.Target, link.Reason)
+					} else {
+						fmt.Fprintf(out, "  %s -> %s\n", path, link.Target)
+					}
+				}
+			}
+			return nil
+		},
+	}
+}
+
+// validatePathPatternExclusive enforces that exactly one of a positional path
+// or a --pattern flag was provided.
+func validatePathPatternExclusive(args []string, pattern string) error {
+	hasPath := len(args) == 1
+	hasPattern := pattern != ""
+	if hasPath == hasPattern {
+		return fmt.Errorf("provide exactly one of a PATH argument or --pattern")
+	}
+	return nil
+}
+
+// newDoctorIgnoreClient builds a dot client from the command's configuration.
+func newDoctorIgnoreClient(cmd *cobra.Command) (*dot.Client, error) {
+	cfg, err := buildConfigWithCmd(cmd)
+	if err != nil {
+		return nil, err
+	}
+	client, err := dot.NewClient(cfg)
+	if err != nil {
+		return nil, formatError(err)
+	}
+	return client, nil
+}

--- a/cmd/dot/doctor_ignore_test.go
+++ b/cmd/dot/doctor_ignore_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runDoctorSubcommand executes `dot doctor <args...>` against the given dirs
+// and returns captured stdout. XDG paths are redirected under the target dir
+// so the user's real config and manifest are never read or written.
+func runDoctorSubcommand(t *testing.T, packageDir, targetDir string, args ...string) (string, error) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(targetDir, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(targetDir, ".local", "share"))
+	setupIntegrationTestFlags(t, CLIFlags{
+		packageDir: packageDir,
+		targetDir:  targetDir,
+	})
+
+	cmd := newDoctorCommand()
+	cmd.SetContext(context.Background())
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func newDoctorIgnoreTestDirs(t *testing.T) (string, string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	packageDir := filepath.Join(tmpDir, "packages")
+	targetDir := filepath.Join(tmpDir, "target")
+	require.NoError(t, os.MkdirAll(packageDir, 0o755))
+	require.NoError(t, os.MkdirAll(targetDir, 0o755))
+	return packageDir, targetDir
+}
+
+func TestDoctorIgnoreCommand_PatternRoundTrip(t *testing.T) {
+	packageDir, targetDir := newDoctorIgnoreTestDirs(t)
+
+	_, err := runDoctorSubcommand(t, packageDir, targetDir, "ignore", "--pattern", "Code/*")
+	require.NoError(t, err)
+
+	out, err := runDoctorSubcommand(t, packageDir, targetDir, "ignores")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Code/*")
+
+	_, err = runDoctorSubcommand(t, packageDir, targetDir, "unignore", "--pattern", "Code/*")
+	require.NoError(t, err)
+
+	out, err = runDoctorSubcommand(t, packageDir, targetDir, "ignores")
+	require.NoError(t, err)
+	assert.NotContains(t, out, "Code/*")
+}
+
+func TestDoctorIgnoreCommand_LinkRoundTrip(t *testing.T) {
+	packageDir, targetDir := newDoctorIgnoreTestDirs(t)
+
+	// A foreign symlink in the target dir, e.g. created by another tool.
+	linkTarget := filepath.Join(t.TempDir(), "profile")
+	require.NoError(t, os.WriteFile(linkTarget, []byte("x"), 0o644))
+	require.NoError(t, os.Symlink(linkTarget, filepath.Join(targetDir, ".nix-profile")))
+
+	_, err := runDoctorSubcommand(t, packageDir, targetDir, "ignore", ".nix-profile", "--reason", "nix managed")
+	require.NoError(t, err)
+
+	out, err := runDoctorSubcommand(t, packageDir, targetDir, "ignores")
+	require.NoError(t, err)
+	assert.Contains(t, out, ".nix-profile")
+	assert.Contains(t, out, "nix managed")
+
+	_, err = runDoctorSubcommand(t, packageDir, targetDir, "unignore", ".nix-profile")
+	require.NoError(t, err)
+
+	out, err = runDoctorSubcommand(t, packageDir, targetDir, "ignores")
+	require.NoError(t, err)
+	assert.NotContains(t, out, ".nix-profile")
+}
+
+func TestDoctorIgnoreCommand_RequiresPathOrPattern(t *testing.T) {
+	packageDir, targetDir := newDoctorIgnoreTestDirs(t)
+
+	_, err := runDoctorSubcommand(t, packageDir, targetDir, "ignore")
+	assert.Error(t, err, "ignore without a path or --pattern must fail")
+
+	_, err = runDoctorSubcommand(t, packageDir, targetDir, "ignore", ".foo", "--pattern", "bar/*")
+	assert.Error(t, err, "ignore with both a path and --pattern must fail")
+}
+
+func TestDoctorIgnoresCommand_EmptyState(t *testing.T) {
+	packageDir, targetDir := newDoctorIgnoreTestDirs(t)
+
+	out, err := runDoctorSubcommand(t, packageDir, targetDir, "ignores")
+	require.NoError(t, err)
+	assert.Contains(t, out, "No ignored links or patterns")
+}

--- a/internal/doctor/patterns.go
+++ b/internal/doctor/patterns.go
@@ -44,6 +44,12 @@ func DefaultPatternCategories() []PatternCategory {
 			Confidence:  "high",
 		},
 		{
+			Name:        "nix",
+			Description: "Nix/home-manager managed",
+			Patterns:    []string{"*/nix/store/*", "*/nix/profiles/*", "*/nix/var/*"},
+			Confidence:  "high",
+		},
+		{
 			Name:        "jetbrains",
 			Description: "JetBrains IDE managed",
 			Patterns:    []string{"*/.local/share/JetBrains/*"},

--- a/internal/doctor/patterns_test.go
+++ b/internal/doctor/patterns_test.go
@@ -126,3 +126,42 @@ func TestCategorizeSymlink_MultipleMatches(t *testing.T) {
 		assert.Equal(t, "first", result.Name)
 	}
 }
+
+func TestDefaultPatternCategories_IncludesNix(t *testing.T) {
+	categories := DefaultPatternCategories()
+
+	var nix *PatternCategory
+	for i := range categories {
+		if categories[i].Name == "nix" {
+			nix = &categories[i]
+			break
+		}
+	}
+
+	if nix == nil {
+		t.Fatal("expected a nix category in default pattern categories")
+	}
+	if nix.Confidence != "high" {
+		t.Errorf("nix category confidence = %q, want %q", nix.Confidence, "high")
+	}
+}
+
+func TestCategorizeSymlink_NixTargets(t *testing.T) {
+	categories := DefaultPatternCategories()
+
+	targets := []string{
+		"/nix/store/qyr0cpkdcb5blkd1ybbg9xh8aiglaplc-home-manager-files/.config/environment.d/10-home-manager.conf",
+		"/home/user/.local/state/nix/profiles/profile",
+		"/nix/var/nix/profiles/per-user/root/channels",
+	}
+	for _, target := range targets {
+		cat := CategorizeSymlink(target, categories)
+		if cat == nil {
+			t.Errorf("CategorizeSymlink(%q) = nil, want nix category", target)
+			continue
+		}
+		if cat.Name != "nix" {
+			t.Errorf("CategorizeSymlink(%q) = %q, want nix", target, cat.Name)
+		}
+	}
+}

--- a/internal/manifest/doctor_test.go
+++ b/internal/manifest/doctor_test.go
@@ -91,3 +91,35 @@ func TestManifest_DoctorState_MultipleOperations(t *testing.T) {
 	assert.Len(t, m.Doctor.IgnoredLinks, 3)
 	assert.True(t, m.UpdatedAt.After(oldTime))
 }
+
+func TestManifest_AddIgnoredPattern_Idempotent(t *testing.T) {
+	m := New()
+
+	m.AddIgnoredPattern("Code/*")
+	m.AddIgnoredPattern("Code/*")
+
+	assert.Equal(t, []string{"Code/*"}, m.Doctor.IgnoredPatterns)
+}
+
+func TestManifest_RemoveIgnoredPattern(t *testing.T) {
+	m := New()
+	m.AddIgnoredPattern("Code/*")
+	m.AddIgnoredPattern("Bootstrap/*")
+
+	assert.True(t, m.RemoveIgnoredPattern("Code/*"))
+	assert.Equal(t, []string{"Bootstrap/*"}, m.Doctor.IgnoredPatterns)
+
+	assert.False(t, m.RemoveIgnoredPattern("Code/*"))
+	assert.False(t, m.RemoveIgnoredPattern("never-added/*"))
+}
+
+func TestManifest_AddIgnoredLink_AfterPartialDoctorState(t *testing.T) {
+	// Simulates a manifest loaded from JSON where doctor state exists with
+	// patterns but ignored_links was absent (nil map after unmarshal).
+	m := New()
+	m.Doctor = &DoctorState{IgnoredPatterns: []string{"Code/*"}}
+
+	m.AddIgnoredLink(".nix-profile", "/nix/store/abc", "nix managed")
+
+	assert.Len(t, m.Doctor.IgnoredLinks, 1)
+}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"slices"
 	"time"
 )
 
@@ -143,12 +144,17 @@ func (m *Manifest) ClearRepository() {
 }
 
 // EnsureDoctorState initializes the doctor state if it doesn't exist.
+// It also initializes nil sub-fields on a partially populated state, which
+// occurs when a manifest is loaded from JSON that omitted one of them.
 func (m *Manifest) EnsureDoctorState() {
 	if m.Doctor == nil {
-		m.Doctor = &DoctorState{
-			IgnoredLinks:    make(map[string]IgnoredLink),
-			IgnoredPatterns: []string{},
-		}
+		m.Doctor = &DoctorState{}
+	}
+	if m.Doctor.IgnoredLinks == nil {
+		m.Doctor.IgnoredLinks = make(map[string]IgnoredLink)
+	}
+	if m.Doctor.IgnoredPatterns == nil {
+		m.Doctor.IgnoredPatterns = []string{}
 	}
 }
 
@@ -179,10 +185,30 @@ func (m *Manifest) RemoveIgnoredLink(path string) bool {
 }
 
 // AddIgnoredPattern adds a glob pattern to the ignore list.
+// Adding a pattern that is already present is a no-op.
 func (m *Manifest) AddIgnoredPattern(pattern string) {
 	m.EnsureDoctorState()
+	if slices.Contains(m.Doctor.IgnoredPatterns, pattern) {
+		return
+	}
 	m.Doctor.IgnoredPatterns = append(m.Doctor.IgnoredPatterns, pattern)
 	m.UpdatedAt = time.Now()
+}
+
+// RemoveIgnoredPattern removes a glob pattern from the ignore list.
+// Returns true if the pattern was found and removed, false otherwise.
+func (m *Manifest) RemoveIgnoredPattern(pattern string) bool {
+	if m.Doctor == nil {
+		return false
+	}
+	for i, existing := range m.Doctor.IgnoredPatterns {
+		if existing == pattern {
+			m.Doctor.IgnoredPatterns = append(m.Doctor.IgnoredPatterns[:i], m.Doctor.IgnoredPatterns[i+1:]...)
+			m.UpdatedAt = time.Now()
+			return true
+		}
+	}
+	return false
 }
 
 // hashString computes SHA256 hash of a string.

--- a/pkg/dot/client.go
+++ b/pkg/dot/client.go
@@ -244,6 +244,32 @@ func (c *Client) Triage(ctx context.Context, scanCfg ScanConfig, opts TriageOpti
 	return c.doctorSvc.Triage(ctx, scanCfg, opts)
 }
 
+// DoctorIgnoreLink adds a target-relative symlink path to the doctor ignore list.
+func (c *Client) DoctorIgnoreLink(ctx context.Context, linkPath, reason string) error {
+	return c.doctorSvc.IgnoreLink(ctx, linkPath, reason)
+}
+
+// DoctorIgnorePattern adds a glob pattern to the doctor ignore list.
+func (c *Client) DoctorIgnorePattern(ctx context.Context, pattern string) error {
+	return c.doctorSvc.IgnorePattern(ctx, pattern)
+}
+
+// DoctorUnignoreLink removes a symlink path from the doctor ignore list.
+func (c *Client) DoctorUnignoreLink(ctx context.Context, linkPath string) error {
+	return c.doctorSvc.UnignoreLink(ctx, linkPath)
+}
+
+// DoctorUnignorePattern removes a glob pattern from the doctor ignore list.
+func (c *Client) DoctorUnignorePattern(ctx context.Context, pattern string) error {
+	return c.doctorSvc.UnignorePattern(ctx, pattern)
+}
+
+// DoctorListIgnored returns the doctor ignore list: ignored links keyed by
+// target-relative path, and ignored glob patterns.
+func (c *Client) DoctorListIgnored(ctx context.Context) (map[string]IgnoredLink, []string, error) {
+	return c.doctorSvc.ListIgnored(ctx)
+}
+
 // Clone clones a dotfiles repository and installs packages.
 //
 // Workflow:

--- a/pkg/dot/doctor_ignore.go
+++ b/pkg/dot/doctor_ignore.go
@@ -8,6 +8,9 @@ import (
 	"github.com/yaklabco/dot/internal/manifest"
 )
 
+// IgnoredLink describes a symlink the user acknowledged and wants doctor to ignore.
+type IgnoredLink = manifest.IgnoredLink
+
 // IgnoreLink adds a symlink to the ignore list.
 func (s *DoctorService) IgnoreLink(ctx context.Context, linkPath, reason string) error {
 	targetPath, err := s.getTargetPath()
@@ -51,6 +54,28 @@ func (s *DoctorService) IgnorePattern(ctx context.Context, pattern string) error
 	m.AddIgnoredPattern(pattern)
 
 	s.logger.Info(ctx, "ignored_pattern", "pattern", pattern)
+
+	return s.manifestSvc.Save(ctx, targetPath, m)
+}
+
+// UnignorePattern removes a glob pattern from the ignore list.
+func (s *DoctorService) UnignorePattern(ctx context.Context, pattern string) error {
+	targetPath, err := s.getTargetPath()
+	if err != nil {
+		return err
+	}
+
+	manifestResult := s.manifestSvc.Load(ctx, targetPath)
+	if !manifestResult.IsOk() {
+		return manifestResult.UnwrapErr()
+	}
+	m := manifestResult.Unwrap()
+
+	if !m.RemoveIgnoredPattern(pattern) {
+		return fmt.Errorf("pattern not in ignore list: %s", pattern)
+	}
+
+	s.logger.Info(ctx, "unignored_pattern", "pattern", pattern)
 
 	return s.manifestSvc.Save(ctx, targetPath, m)
 }

--- a/pkg/dot/doctor_ignore_test.go
+++ b/pkg/dot/doctor_ignore_test.go
@@ -1,0 +1,99 @@
+package dot
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklabco/dot/internal/adapters"
+	"github.com/yaklabco/dot/internal/manifest"
+)
+
+func newIgnoreTestService(t *testing.T) (*DoctorService, *adapters.MemFS) {
+	t.Helper()
+	fs := adapters.NewMemFS()
+	ctx := context.Background()
+	require.NoError(t, fs.MkdirAll(ctx, "/home", 0o755))
+	require.NoError(t, fs.MkdirAll(ctx, "/packages", 0o755))
+	store := manifest.NewFSManifestStore(fs)
+	manifestSvc := newManifestService(fs, adapters.NewNoopLogger(), store)
+	svc := newDoctorService(fs, adapters.NewNoopLogger(), manifestSvc, "/packages", "/home")
+	return svc, fs
+}
+
+func TestDoctorService_IgnoreAndUnignorePattern(t *testing.T) {
+	svc, _ := newIgnoreTestService(t)
+	ctx := context.Background()
+
+	require.NoError(t, svc.IgnorePattern(ctx, "Code/*"))
+
+	_, patterns, err := svc.ListIgnored(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Code/*"}, patterns)
+
+	// Adding the same pattern again must not duplicate it.
+	require.NoError(t, svc.IgnorePattern(ctx, "Code/*"))
+	_, patterns, err = svc.ListIgnored(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Code/*"}, patterns)
+
+	require.NoError(t, svc.UnignorePattern(ctx, "Code/*"))
+	_, patterns, err = svc.ListIgnored(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, patterns)
+}
+
+func TestDoctorService_UnignorePattern_NotFound(t *testing.T) {
+	svc, _ := newIgnoreTestService(t)
+	ctx := context.Background()
+
+	err := svc.UnignorePattern(ctx, "nope/*")
+	assert.Error(t, err)
+}
+
+func TestDoctorService_IgnoreLinkRoundTrip(t *testing.T) {
+	svc, fs := newIgnoreTestService(t)
+	ctx := context.Background()
+
+	require.NoError(t, fs.Symlink(ctx, "/nix/store/abc/profile", "/home/.nix-profile"))
+
+	require.NoError(t, svc.IgnoreLink(ctx, ".nix-profile", "nix managed"))
+
+	links, _, err := svc.ListIgnored(ctx)
+	require.NoError(t, err)
+	require.Contains(t, links, ".nix-profile")
+	assert.Equal(t, "/nix/store/abc/profile", links[".nix-profile"].Target)
+	assert.Equal(t, "nix managed", links[".nix-profile"].Reason)
+
+	require.NoError(t, svc.UnignoreLink(ctx, ".nix-profile"))
+	links, _, err = svc.ListIgnored(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, links)
+}
+
+func TestClient_DoctorIgnoreSurface(t *testing.T) {
+	fs := adapters.NewMemFS()
+	ctx := context.Background()
+	require.NoError(t, fs.MkdirAll(ctx, "/home", 0o755))
+	require.NoError(t, fs.MkdirAll(ctx, "/packages", 0o755))
+
+	client, err := NewClient(Config{
+		PackageDir: "/packages",
+		TargetDir:  "/home",
+		FS:         fs,
+		Logger:     adapters.NewNoopLogger(),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, client.DoctorIgnorePattern(ctx, "Bootstrap/*"))
+	links, patterns, err := client.DoctorListIgnored(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, links)
+	assert.Equal(t, []string{"Bootstrap/*"}, patterns)
+
+	require.NoError(t, client.DoctorUnignorePattern(ctx, "Bootstrap/*"))
+	_, patterns, err = client.DoctorListIgnored(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, patterns)
+}


### PR DESCRIPTION
Fixes #67.

- New subcommands wired to the existing DoctorService ignore methods:
  - `dot doctor ignore [PATH|--pattern GLOB] [--reason ...]`
  - `dot doctor unignore [PATH|--pattern GLOB]`
  - `dot doctor ignores`
- New `DoctorService.UnignorePattern` and `Client.DoctorIgnore*`/`DoctorListIgnored` wrappers; `IgnoredLink` aliased into the public package surface.
- `Manifest.RemoveIgnoredPattern` added; `AddIgnoredPattern` is now idempotent.
- Crash fix: `EnsureDoctorState` initializes nil sub-fields, so a manifest whose JSON contains doctor state without `ignored_links` no longer panics `AddIgnoredLink` (previously reachable from triage on a hand-edited or partially populated manifest).
- New high-confidence `nix` orphan pattern category (`*/nix/store/*", "*/nix/profiles/*", "*/nix/var/*`) so nix and home-manager symlinks categorize and `--auto-ignore` works on NixOS machines.
- README documents the new commands.

Tests: unit coverage for manifest pattern add/remove/idempotency and the nil-submap regression, service and client round-trips over MemFS, nix categorization, and cmd-level integration tests for all three subcommands (XDG paths redirected into the test temp dirs so the user environment is never touched). Full suite green under -race; golangci-lint 0 issues.