### PR TITLE
docs: align doctor ignore command syntax with shipped CLI

### DIFF
--- a/docs/developer/doctor-system-ux-design.md
+++ b/docs/developer/doctor-system-ux-design.md
@@ -49,10 +49,10 @@ dot doctor fix --dry-run       # Preview changes
 dot doctor clean orphans       # Remove orphaned symlinks
 dot doctor sync manifest       # Sync manifest with filesystem
 
-# Management Commands
-dot doctor ignore add <path>   # Add to ignore list
-dot doctor ignore list         # Show ignored items
-dot doctor ignore remove <path> # Remove from ignore list
+# Management Commands (implemented)
+dot doctor ignore <path>       # Add to ignore list (or --pattern <glob>, --reason <text>)
+dot doctor ignores             # Show ignored items
+dot doctor unignore <path>     # Remove from ignore list (or --pattern <glob>)
 dot doctor history             # Show doctor operation history
 dot doctor undo                # Undo last doctor operation
 ```
@@ -2649,9 +2649,10 @@ dot doctor check profile                # Validate machine profile
 dot doctor migrate from-stow            # Migrate from GNU Stow
 dot doctor check conflicts <package>    # Pre-manage conflict check
 
-# Management
-dot doctor ignore add <path>            # Add to ignore list
-dot doctor ignore list                  # Show ignored items
+# Management (ignore commands implemented)
+dot doctor ignore <path>                # Add to ignore list
+dot doctor ignores                      # Show ignored items
+dot doctor unignore <path>              # Remove from ignore list
 dot doctor history                      # Show operation history
 ```
 

--- a/docs/developer/triage-improvements.md
+++ b/docs/developer/triage-improvements.md
@@ -11,7 +11,7 @@
 2. No color in triage output
 3. No confirmation summary before saving changes
 4. Already-ignored items shown again in triage
-5. No way to review/manage existing ignored items
+5. No way to review/manage existing ignored items (resolved: `dot doctor ignore`, `dot doctor unignore`, `dot doctor ignores`)
 6. Adoption marked but never executed (orphaned feature)
 
 ### Missing Features
@@ -163,7 +163,7 @@ dot doctor --triage --show-diff
 5. **MEDIUM**: Add dry-run mode
 6. **MEDIUM**: Deduplicate patterns
 7. **LOW**: Color output
-8. **LOW**: Manage existing ignores command
+8. **DONE**: Manage existing ignores command (shipped as `dot doctor ignore` / `unignore` / `ignores`)
 9. **FUTURE**: TUI interface
 10. **FUTURE**: Export/Import
 


### PR DESCRIPTION
Follow-up to #70. The doctor UX design doc specified `doctor ignore add/list/remove`; the shipped surface is `doctor ignore [PATH]`, `doctor ignores`, `doctor unignore [PATH]`. Following the old syntax would now silently add a link literally named `add` to the ignore list. Also marks the triage-improvements backlog item for ignore management as done.