### PR TITLE
ci: make the release workflow triggerable and its lint gate deterministic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,16 @@ on:
   push:
     tags:
       - 'v*'
+  # Tags created by release-please are pushed with the workflow GITHUB_TOKEN,
+  # and events from that token never trigger other workflows, so a tag push
+  # from the release PR merge does not start this job. workflow_dispatch is
+  # the recovery path: run it against the tag release-please created.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to release (e.g. v0.6.6)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -18,6 +28,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Fetch all tags
         run: git fetch --force --tags
@@ -28,16 +39,14 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Install golangci-lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-
       - name: Run tests
         run: make test
 
-      - name: Run linters
-        run: make lint
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.12.2
+          args: --timeout=5m
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,9 +1,11 @@
 version: 2
 
+# Lint runs in the release workflow via golangci/golangci-lint-action (pinned),
+# not here: the hook required golangci-lint on PATH inside goreleaser's
+# environment, which made releases fail on installer flakes.
 before:
   hooks:
     - go test ./...
-    - golangci-lint run
     - go mod tidy
 
 builds:

--- a/docs/developer/release-workflow.md
+++ b/docs/developer/release-workflow.md
@@ -46,10 +46,23 @@ When changes are pushed to `main`, the Release Please workflow runs.
 
 Once the Release PR is merged:
 
-1. Release Please automatically creates a git tag (e.g., `v1.2.3`).
-2. This tag push triggers the **Release** workflow (`.github/workflows/release.yml`).
-3. GoReleaser builds the binaries and publishes the GitHub Release.
+1. Release Please automatically creates a git tag (e.g., `v1.2.3`) and a GitHub Release entry.
+2. A tag push triggers the **Release** workflow (`.github/workflows/release.yml`).
+3. GoReleaser builds the binaries and attaches them to the GitHub Release.
 4. Homebrew taps are updated automatically.
+
+Caveat: Release Please pushes the tag with the workflow `GITHUB_TOKEN`, and
+events created by that token never trigger other workflows. The Release
+workflow therefore does not start on its own after the release PR merges.
+Start it manually with `workflow_dispatch`, passing the tag Release Please
+created:
+
+```bash
+gh workflow run release.yml -f tag=v1.2.3
+```
+
+Deleting and re-pushing the tag from a user account also works. A release
+entry without binaries means this step was skipped.
 
 ## Local Verification
 
@@ -76,6 +89,9 @@ make changelog-next
 
 - Check the `Release` workflow in GitHub Actions.
 - Ensure the tag was created successfully by Release Please.
+- If the tag exists and the release entry has no binaries, the Release
+  workflow never ran (see the `GITHUB_TOKEN` caveat above). Run
+  `gh workflow run release.yml -f tag=<tag>`.
 
 ## Manual Hotfixes
 


### PR DESCRIPTION
## Summary

The v0.6.6 release surfaced two pipeline defects:

1. **Release workflow never triggers from release-please tags.** Tags are pushed with the workflow GITHUB_TOKEN, whose events do not trigger other workflows. No Release run has fired since v0.6.0; every release since shipped as a bare tag with no binaries, and the Homebrew formula went stale. This adds a workflow_dispatch trigger that takes the tag to release, and documents the caveat and recovery in docs/developer/release-workflow.md.

2. **Lint install in the release job is unpinned and fragile.** The curl installer fetched latest and failed the v0.6.6 run with a tarball checksum mismatch. Replaced with golangci/golangci-lint-action pinned to v2.12.2, matching ci.yml, and the redundant golangci-lint pre-hook was dropped from .goreleaser.yml (it required the binary on PATH inside goreleaser's environment).

v0.6.6 itself was published by re-pushing the tag from a user account, which does trigger the workflow.

## Verification
- Workflow YAML parses (gh accepts it at push time)
- Lint gate identical to CI: same action, same pinned version, same config