### PR TITLE
feat(sync): add dot sync for multi-machine reconciliation

### DIFF
--- a/cmd/dot/root.go
+++ b/cmd/dot/root.go
@@ -165,6 +165,7 @@ comprehensive conflict detection, and incremental updates.`,
 		newDoctorCommand(),
 		newConfigCommand(),
 		newCloneCommand(),
+		newSyncCommand(),
 		newUpgradeCommand(version),
 	)
 

--- a/cmd/dot/sync.go
+++ b/cmd/dot/sync.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -97,7 +99,7 @@ func runSync(cmd *cobra.Command, push bool) error {
 		return err
 	}
 
-	if err := syncRelink(ctx, formatter, client); err != nil {
+	if err := syncRelink(ctx, formatter, client, cfg.PackageDir, cfg.DryRun); err != nil {
 		return err
 	}
 
@@ -150,25 +152,35 @@ func reportRebaseConflict(errFormatter *output.Formatter, conflict gitsync.ErrRe
 	errFormatter.Indent(1, fmt.Sprintf("Resolve the conflicts in %s, then run 'dot sync' again.", conflict.Dir))
 }
 
-// syncRelink remanages every package in the manifest and reports package health.
-// A run with nothing to do stays silent apart from the health summary.
-func syncRelink(ctx context.Context, formatter *output.Formatter, client *dot.Client) error {
+// syncRelink remanages every manifest package that still exists in the package
+// directory and reports package health. A run with nothing to do stays silent
+// apart from the health summary.
+func syncRelink(ctx context.Context, formatter *output.Formatter, client *dot.Client, packageDir string, dryRun bool) error {
 	installed, err := client.List(ctx)
 	if err != nil {
 		return err
 	}
 
 	names := make([]string, 0, len(installed))
+	missing := make([]string, 0)
 	for _, pkg := range installed {
-		names = append(names, pkg.Name)
+		if packageExists(packageDir, pkg.Name) {
+			names = append(names, pkg.Name)
+			continue
+		}
+		missing = append(missing, pkg.Name)
 	}
+
+	// A package deleted upstream must not abort the sync: report it and carry
+	// on, so the health summary and the dirty-tree warning still run.
+	reportMissingPackages(formatter, missing)
 
 	if len(names) > 0 {
 		err = client.Remanage(ctx, names...)
 		var noChanges dot.ErrNoChanges
 		switch {
 		case err == nil:
-			formatter.Success("remanaged", len(names), "package", "packages")
+			reportRelinked(formatter, len(names), dryRun)
 		case errors.As(err, &noChanges):
 			// Nothing changed: stay quiet.
 		default:
@@ -177,6 +189,40 @@ func syncRelink(ctx context.Context, formatter *output.Formatter, client *dot.Cl
 	}
 
 	return reportHealth(ctx, formatter, client)
+}
+
+// packageExists reports whether a manifest package still has a directory in
+// the package directory.
+func packageExists(packageDir, name string) bool {
+	info, err := os.Stat(filepath.Join(packageDir, name))
+	return err == nil && info.IsDir()
+}
+
+// reportMissingPackages warns about manifest packages whose directory is gone,
+// which is what a package deleted on another machine looks like after a pull.
+func reportMissingPackages(formatter *output.Formatter, missing []string) {
+	if len(missing) == 0 {
+		return
+	}
+
+	formatter.Warning(fmt.Sprintf("%s in the manifest missing from the package directory",
+		formatCount(len(missing), "package", "packages")))
+	for _, name := range missing {
+		formatter.Indent(1, name)
+	}
+	formatter.Indent(1, fmt.Sprintf("Run 'dot unmanage %s' to remove the leftover links.",
+		strings.Join(missing, " ")))
+}
+
+// reportRelinked prints the outcome of the remanage step. A dry run never
+// claims work it did not do.
+func reportRelinked(formatter *output.Formatter, count int, dryRun bool) {
+	if dryRun {
+		formatter.Info(fmt.Sprintf("Dry run: %s would be remanaged",
+			formatCount(count, "package", "packages")))
+		return
+	}
+	formatter.Success("remanaged", count, "package", "packages")
 }
 
 // reportHealth prints the healthy-package summary line.

--- a/cmd/dot/sync.go
+++ b/cmd/dot/sync.go
@@ -1,0 +1,264 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/yaklabco/dot/internal/cli/output"
+	"github.com/yaklabco/dot/internal/gitsync"
+	"github.com/yaklabco/dot/pkg/dot"
+)
+
+// maxListedCommits caps how many pulled commit subjects are printed.
+const maxListedCommits = 10
+
+// newSyncCommand creates the sync command.
+func newSyncCommand() *cobra.Command {
+	var push bool
+
+	cmd := &cobra.Command{
+		Use:   "sync",
+		Short: "Reconcile this machine with the dotfiles repository",
+		Long: `Reconcile this machine with the dotfiles repository.
+
+sync is the single verb for multi-machine work. In the package directory,
+which must be a git repository, it:
+
+  1. Pulls with rebase and autostash, reporting the commits gained
+  2. Remanages every package recorded in the manifest, so files added or
+     removed upstream are linked or unlinked
+  3. Prints how many packages are healthy
+  4. Warns about uncommitted local edits, grouped by package
+
+Edits made through a symlink land in the package directory, which leaves the
+repository dirty. The warning block surfaces those edits; --push commits and
+pushes them.
+
+If the rebase stops with conflicts, sync prints the conflicted paths and
+exits non-zero without attempting to resolve them. Resolve them in the
+package directory, then run dot sync again.`,
+		Example: `  # Pull, relink, and report local state
+  dot sync
+
+  # Also commit and push local edits
+  dot sync --push
+
+  # Preview without touching git
+  dot --dry-run sync`,
+		Args: argsWithUsage(cobra.NoArgs),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runSync(cmd, push)
+		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
+	}
+
+	cmd.Flags().BoolVar(&push, "push", false, "commit and push local changes after syncing")
+
+	return cmd
+}
+
+// runSync handles the sync command execution.
+func runSync(cmd *cobra.Command, push bool) error {
+	cfg, err := buildConfigWithCmd(cmd)
+	if err != nil {
+		return err
+	}
+
+	repo, err := gitsync.Open(cfg.PackageDir)
+	if err != nil {
+		return err
+	}
+
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if err := repo.EnsureRepository(ctx); err != nil {
+		return err
+	}
+
+	client, err := dot.NewClient(cfg)
+	if err != nil {
+		return err
+	}
+
+	colorize := shouldUseColor()
+	formatter := output.NewFormatter(cmd.OutOrStdout(), colorize)
+	errFormatter := output.NewFormatter(cmd.ErrOrStderr(), colorize)
+
+	if err := syncPull(ctx, formatter, errFormatter, repo, cfg.DryRun); err != nil {
+		return err
+	}
+
+	if err := syncRelink(ctx, formatter, client); err != nil {
+		return err
+	}
+
+	return syncWorkingTree(ctx, formatter, repo, cfg.DryRun, push)
+}
+
+// syncPull pulls with rebase and reports the commits gained. Rebase conflicts
+// are reported through errFormatter and returned so the caller exits non-zero.
+func syncPull(ctx context.Context, formatter, errFormatter *output.Formatter, repo *gitsync.Repo, dryRun bool) error {
+	if dryRun {
+		formatter.Info(fmt.Sprintf("Dry run: skipping git pull in %s", repo.Dir()))
+		return nil
+	}
+
+	result, err := repo.Pull(ctx)
+	if err != nil {
+		var conflict gitsync.ErrRebaseConflict
+		if errors.As(err, &conflict) {
+			reportRebaseConflict(errFormatter, conflict)
+		}
+		return err
+	}
+
+	reportPull(formatter, result)
+	return nil
+}
+
+// reportPull prints the outcome of a pull.
+func reportPull(formatter *output.Formatter, result gitsync.PullResult) {
+	if result.UpToDate() {
+		formatter.Info("Already up to date")
+		return
+	}
+
+	formatter.Success("pulled", len(result.Commits), "commit", "commits")
+	if len(result.Commits) > maxListedCommits {
+		return
+	}
+	for _, commit := range result.Commits {
+		formatter.Bullet(fmt.Sprintf("%s %s", commit.Hash, commit.Subject))
+	}
+}
+
+// reportRebaseConflict prints the conflicted paths and how to recover.
+func reportRebaseConflict(errFormatter *output.Formatter, conflict gitsync.ErrRebaseConflict) {
+	errFormatter.Error("Rebase stopped with conflicts")
+	for _, path := range conflict.Paths {
+		errFormatter.Bullet(path)
+	}
+	errFormatter.Indent(1, fmt.Sprintf("Resolve the conflicts in %s, then run 'dot sync' again.", conflict.Dir))
+}
+
+// syncRelink remanages every package in the manifest and reports package health.
+// A run with nothing to do stays silent apart from the health summary.
+func syncRelink(ctx context.Context, formatter *output.Formatter, client *dot.Client) error {
+	installed, err := client.List(ctx)
+	if err != nil {
+		return err
+	}
+
+	names := make([]string, 0, len(installed))
+	for _, pkg := range installed {
+		names = append(names, pkg.Name)
+	}
+
+	if len(names) > 0 {
+		err = client.Remanage(ctx, names...)
+		var noChanges dot.ErrNoChanges
+		switch {
+		case err == nil:
+			formatter.Success("remanaged", len(names), "package", "packages")
+		case errors.As(err, &noChanges):
+			// Nothing changed: stay quiet.
+		default:
+			return err
+		}
+	}
+
+	return reportHealth(ctx, formatter, client)
+}
+
+// reportHealth prints the healthy-package summary line.
+func reportHealth(ctx context.Context, formatter *output.Formatter, client *dot.Client) error {
+	status, err := client.Status(ctx)
+	if err != nil {
+		return err
+	}
+
+	healthy := 0
+	for _, pkg := range status.Packages {
+		if pkg.IsHealthy {
+			healthy++
+		}
+	}
+
+	formatter.Info(fmt.Sprintf("Packages: %d/%d healthy", healthy, len(status.Packages)))
+	return nil
+}
+
+// syncWorkingTree reports uncommitted local edits and, when push is set,
+// commits and pushes them.
+func syncWorkingTree(ctx context.Context, formatter *output.Formatter, repo *gitsync.Repo, dryRun, push bool) error {
+	entries, err := repo.Status(ctx)
+	if err != nil {
+		return err
+	}
+
+	groups := gitsync.GroupByPackage(entries)
+	if len(groups) == 0 {
+		if push {
+			formatter.Info("Nothing to commit; the package directory is clean")
+		}
+		return nil
+	}
+
+	reportDirty(formatter, repo.Dir(), groups, push)
+
+	if !push {
+		return nil
+	}
+
+	if dryRun {
+		formatter.Info("Dry run: skipping commit and push")
+		return nil
+	}
+
+	message := gitsync.CommitMessage(currentHostname(), groups)
+	if err := repo.CommitAll(ctx, message); err != nil {
+		return err
+	}
+	formatter.SuccessSimple(fmt.Sprintf("Committed %s: %s",
+		formatCount(len(groups), "package", "packages"), message))
+
+	if err := repo.Push(ctx); err != nil {
+		return err
+	}
+	formatter.SuccessSimple("Pushed to remote")
+
+	return nil
+}
+
+// reportDirty prints the uncommitted changes grouped by package.
+func reportDirty(formatter *output.Formatter, dir string, groups []gitsync.PackageGroup, push bool) {
+	formatter.Warning(fmt.Sprintf("Uncommitted changes in %s", dir))
+	for _, group := range groups {
+		formatter.Indent(1, group.Label())
+		for _, entry := range group.Entries {
+			formatter.Indent(2, fmt.Sprintf("%s %s", entry.Code(), entry.Path))
+		}
+	}
+	if !push {
+		formatter.Indent(1, "Run 'dot sync --push' to commit and push, or commit manually.")
+	}
+}
+
+// currentHostname returns this machine's hostname, or an empty string when it
+// cannot be determined.
+func currentHostname() string {
+	name, err := os.Hostname()
+	if err != nil {
+		return ""
+	}
+	return name
+}

--- a/cmd/dot/sync_test.go
+++ b/cmd/dot/sync_test.go
@@ -120,6 +120,16 @@ func (s syncSandbox) publish(t *testing.T, relPath, content, message string) {
 	gitInDir(t, other, "push")
 }
 
+// remove deletes a path from an independent clone and pushes the deletion.
+func (s syncSandbox) remove(t *testing.T, relPath, message string) {
+	t.Helper()
+	other := s.cloneOrigin(t, "remover")
+	require.NoError(t, os.RemoveAll(filepath.Join(other, relPath)))
+	gitInDir(t, other, "add", "--all")
+	gitInDir(t, other, "commit", "-m", message)
+	gitInDir(t, other, "push")
+}
+
 // manage installs packages through the manage command in the sandbox.
 func manageInSandbox(t *testing.T, packages ...string) {
 	t.Helper()
@@ -215,6 +225,43 @@ func TestSyncCommand_UpToDateIsQuiet(t *testing.T) {
 	assert.NotContains(t, stdout, "Uncommitted changes")
 	assert.Contains(t, stdout, "1/1")
 	_ = sandbox
+}
+
+func TestSyncCommand_PackageRemovedUpstreamKeepsGoing(t *testing.T) {
+	sandbox := newSyncSandbox(t)
+	manageInSandbox(t, "dot-vim")
+
+	// A local edit keeps the tree dirty so the warning block is observable.
+	require.NoError(t, os.WriteFile(filepath.Join(sandbox.packageDir, "README.md"), []byte("notes\n"), 0o644))
+
+	sandbox.remove(t, "dot-vim", "chore: retire the vim package")
+
+	stdout, _, err := runSyncCommand(t)
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "Pulled 1 commit")
+	assert.Contains(t, stdout, "dot-vim", "the package that vanished upstream is named")
+	assert.Contains(t, stdout, "dot unmanage", "the warning explains how to finish the removal")
+	assert.Contains(t, stdout, "Packages:", "the health summary still runs")
+	assert.Contains(t, stdout, "Uncommitted changes", "the dirty-tree warning still runs")
+}
+
+func TestSyncCommand_DryRunDoesNotClaimRemanage(t *testing.T) {
+	sandbox := newSyncSandbox(t)
+	manageInSandbox(t, "dot-vim")
+
+	// Removing a link gives remanage real work to do on a live run.
+	link := filepath.Join(sandbox.targetDir, ".vim", ".vimrc")
+	require.NoError(t, os.Remove(link))
+
+	cliFlags.dryRun = true
+	t.Cleanup(func() { cliFlags.dryRun = false })
+
+	stdout, _, err := runSyncCommand(t)
+	require.NoError(t, err)
+
+	assert.NotContains(t, stdout, "Remanaged", "a dry run never claims work it did not do")
+	assert.NoFileExists(t, link, "a dry run does not restore the link")
 }
 
 func TestSyncCommand_DirtyTreeWarning(t *testing.T) {

--- a/cmd/dot/sync_test.go
+++ b/cmd/dot/sync_test.go
@@ -185,6 +185,8 @@ func TestSyncCommand_ContentOnlyPull(t *testing.T) {
 
 	assert.Contains(t, stdout, "Pulled 1 commit")
 	assert.Contains(t, stdout, "feat(vim): enable ruler")
+	// The relink pass still runs and reports itself, as the docs describe.
+	assert.Contains(t, stdout, "Remanaged 1 package")
 
 	// A content-only change does not alter the link set.
 	assert.Equal(t, linksBefore, listLinks(t, sandbox.targetDir))
@@ -215,7 +217,7 @@ func TestSyncCommand_StructuralPullCreatesLink(t *testing.T) {
 }
 
 func TestSyncCommand_UpToDateIsQuiet(t *testing.T) {
-	sandbox := newSyncSandbox(t)
+	newSyncSandbox(t)
 	manageInSandbox(t, "dot-vim")
 
 	stdout, _, err := runSyncCommand(t)
@@ -224,7 +226,6 @@ func TestSyncCommand_UpToDateIsQuiet(t *testing.T) {
 	assert.Contains(t, stdout, "Already up to date")
 	assert.NotContains(t, stdout, "Uncommitted changes")
 	assert.Contains(t, stdout, "1/1")
-	_ = sandbox
 }
 
 func TestSyncCommand_PackageRemovedUpstreamKeepsGoing(t *testing.T) {

--- a/cmd/dot/sync_test.go
+++ b/cmd/dot/sync_test.go
@@ -320,6 +320,28 @@ func TestSyncCommand_PushRoundTrip(t *testing.T) {
 	assert.True(t, strings.HasPrefix(strings.TrimSpace(subject), "sync: "), "subject was %q", subject)
 }
 
+func TestSyncCommand_PushRespectsFailingPreCommitHook(t *testing.T) {
+	sandbox := newSyncSandbox(t)
+	manageInSandbox(t, "dot-vim")
+
+	// A hook that rejects the commit stands in for any repository policy.
+	hooks := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(hooks, "pre-commit"), []byte("#!/bin/sh\nexit 1\n"), 0o700))
+	gitInDir(t, sandbox.packageDir, "config", "core.hooksPath", hooks)
+
+	require.NoError(t, os.WriteFile(filepath.Join(sandbox.packageDir, "dot-vim", "dot-vimrc"), []byte("set number\nset ruler\n"), 0o644))
+
+	stdout, _, err := runSyncCommand(t, "--push")
+	require.Error(t, err, "sync never bypasses hooks with --no-verify")
+
+	assert.NotContains(t, stdout, "Pushed")
+
+	verify := sandbox.cloneOrigin(t, "verify")
+	content, err := os.ReadFile(filepath.Join(verify, "dot-vim", "dot-vimrc"))
+	require.NoError(t, err)
+	assert.NotContains(t, string(content), "set ruler", "the rejected edit never reached the remote")
+}
+
 func TestSyncCommand_PushWithCleanTree(t *testing.T) {
 	newSyncSandbox(t)
 	manageInSandbox(t, "dot-vim")

--- a/cmd/dot/sync_test.go
+++ b/cmd/dot/sync_test.go
@@ -1,0 +1,355 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// syncSandbox holds the paths of an isolated sync test environment.
+type syncSandbox struct {
+	origin     string
+	packageDir string
+	targetDir  string
+}
+
+// requireGitBinary skips the test when git is not installed.
+func requireGitBinary(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+}
+
+// gitInDir runs a git command and fails the test when it errors.
+func gitInDir(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %v failed: %s", args, out)
+	return string(out)
+}
+
+// configureSyncRepo applies the local git settings needed for hermetic commits.
+func configureSyncRepo(t *testing.T, dir string) {
+	t.Helper()
+	gitInDir(t, dir, "config", "user.name", "dot test")
+	gitInDir(t, dir, "config", "user.email", "dot@example.test")
+	gitInDir(t, dir, "config", "commit.gpgsign", "false")
+	gitInDir(t, dir, "config", "core.hooksPath", t.TempDir())
+}
+
+// newSyncSandbox builds a bare origin repository seeded with a dot-vim package,
+// clones it as the package directory, and points every ambient path at
+// temporary directories so the real HOME is never touched.
+func newSyncSandbox(t *testing.T) syncSandbox {
+	t.Helper()
+	requireGitBinary(t)
+
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	require.NoError(t, os.MkdirAll(home, 0o755))
+
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(home, ".gitconfig"))
+	t.Setenv("GIT_CONFIG_SYSTEM", filepath.Join(home, ".gitconfig-system"))
+	t.Setenv("GIT_AUTHOR_NAME", "dot test")
+	t.Setenv("GIT_AUTHOR_EMAIL", "dot@example.test")
+	t.Setenv("GIT_COMMITTER_NAME", "dot test")
+	t.Setenv("GIT_COMMITTER_EMAIL", "dot@example.test")
+
+	origin := filepath.Join(root, "origin.git")
+	seed := filepath.Join(root, "seed")
+	packageDir := filepath.Join(root, "dotfiles")
+	targetDir := filepath.Join(root, "target")
+
+	require.NoError(t, os.MkdirAll(origin, 0o755))
+	gitInDir(t, origin, "init", "--bare", "-b", "main")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(seed, "dot-vim"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(seed, "dot-vim", "dot-vimrc"), []byte("set number\n"), 0o644))
+	gitInDir(t, seed, "init", "-b", "main")
+	configureSyncRepo(t, seed)
+	gitInDir(t, seed, "add", ".")
+	gitInDir(t, seed, "commit", "-m", "seed: initial packages")
+	gitInDir(t, seed, "remote", "add", "origin", origin)
+	gitInDir(t, seed, "push", "-u", "origin", "main")
+
+	gitInDir(t, root, "clone", origin, packageDir)
+	configureSyncRepo(t, packageDir)
+	require.NoError(t, os.MkdirAll(targetDir, 0o755))
+
+	setupIntegrationTestFlags(t, CLIFlags{
+		packageDir: packageDir,
+		targetDir:  targetDir,
+	})
+
+	return syncSandbox{origin: origin, packageDir: packageDir, targetDir: targetDir}
+}
+
+// cloneOrigin makes an independent clone of the sandbox origin.
+func (s syncSandbox) cloneOrigin(t *testing.T, name string) string {
+	t.Helper()
+	parent := t.TempDir()
+	gitInDir(t, parent, "clone", s.origin, name)
+	dir := filepath.Join(parent, name)
+	configureSyncRepo(t, dir)
+	return dir
+}
+
+// publish commits a change from an independent clone and pushes it to origin.
+func (s syncSandbox) publish(t *testing.T, relPath, content, message string) {
+	t.Helper()
+	other := s.cloneOrigin(t, "publisher")
+	full := filepath.Join(other, relPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+	require.NoError(t, os.WriteFile(full, []byte(content), 0o644))
+	gitInDir(t, other, "add", "--all")
+	gitInDir(t, other, "commit", "-m", message)
+	gitInDir(t, other, "push")
+}
+
+// manage installs packages through the manage command in the sandbox.
+func manageInSandbox(t *testing.T, packages ...string) {
+	t.Helper()
+	cmd := newManageCommand()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetContext(context.Background())
+	cmd.SetArgs(packages)
+	require.NoError(t, cmd.Execute())
+}
+
+// runSyncCommand executes the sync command and returns stdout, stderr, and error.
+func runSyncCommand(t *testing.T, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	var outBuf, errBuf bytes.Buffer
+	cmd := newSyncCommand()
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&errBuf)
+	cmd.SetContext(context.Background())
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	return outBuf.String(), errBuf.String(), err
+}
+
+// listLinks returns the sorted symlink paths under dir.
+func listLinks(t *testing.T, dir string) []string {
+	t.Helper()
+	links := make([]string, 0)
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			links = append(links, path)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	return links
+}
+
+func TestSyncCommand_ContentOnlyPull(t *testing.T) {
+	sandbox := newSyncSandbox(t)
+	manageInSandbox(t, "dot-vim")
+
+	linksBefore := listLinks(t, sandbox.targetDir)
+	require.NotEmpty(t, linksBefore)
+
+	sandbox.publish(t, "dot-vim/dot-vimrc", "set number\nset ruler\n", "feat(vim): enable ruler")
+
+	stdout, _, err := runSyncCommand(t)
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "Pulled 1 commit")
+	assert.Contains(t, stdout, "feat(vim): enable ruler")
+
+	// A content-only change does not alter the link set.
+	assert.Equal(t, linksBefore, listLinks(t, sandbox.targetDir))
+
+	content, err := os.ReadFile(filepath.Join(sandbox.targetDir, ".vim", ".vimrc"))
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "set ruler")
+}
+
+func TestSyncCommand_StructuralPullCreatesLink(t *testing.T) {
+	sandbox := newSyncSandbox(t)
+	manageInSandbox(t, "dot-vim")
+
+	newLink := filepath.Join(sandbox.targetDir, ".vim", "colors", "solarized.vim")
+	require.NoFileExists(t, newLink)
+
+	sandbox.publish(t, "dot-vim/colors/solarized.vim", "\" solarized\n", "feat(vim): add solarized colors")
+
+	stdout, _, err := runSyncCommand(t)
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "Pulled 1 commit")
+	assert.FileExists(t, newLink)
+
+	info, err := os.Lstat(newLink)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&os.ModeSymlink, "new package file is linked into the target")
+}
+
+func TestSyncCommand_UpToDateIsQuiet(t *testing.T) {
+	sandbox := newSyncSandbox(t)
+	manageInSandbox(t, "dot-vim")
+
+	stdout, _, err := runSyncCommand(t)
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "Already up to date")
+	assert.NotContains(t, stdout, "Uncommitted changes")
+	assert.Contains(t, stdout, "1/1")
+	_ = sandbox
+}
+
+func TestSyncCommand_DirtyTreeWarning(t *testing.T) {
+	sandbox := newSyncSandbox(t)
+	manageInSandbox(t, "dot-vim")
+
+	// Simulate an edit made through a symlink: the package clone goes dirty.
+	require.NoError(t, os.WriteFile(filepath.Join(sandbox.packageDir, "dot-vim", "dot-vimrc"), []byte("set number\nset ruler\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(sandbox.packageDir, "dot-zsh"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sandbox.packageDir, "dot-zsh", "dot-zshrc"), []byte("alias l=ls\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(sandbox.packageDir, "README.md"), []byte("notes\n"), 0o644))
+
+	stdout, _, err := runSyncCommand(t)
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "Uncommitted changes")
+	assert.Contains(t, stdout, sandbox.packageDir)
+	assert.Contains(t, stdout, "dot-vim")
+	assert.Contains(t, stdout, "dot-vim/dot-vimrc")
+	assert.Contains(t, stdout, "dot-zsh")
+	assert.Contains(t, stdout, "README.md")
+	assert.Contains(t, stdout, "dot sync --push")
+}
+
+func TestSyncCommand_CleanTreePrintsNoWarning(t *testing.T) {
+	newSyncSandbox(t)
+	manageInSandbox(t, "dot-vim")
+
+	stdout, _, err := runSyncCommand(t)
+	require.NoError(t, err)
+
+	assert.NotContains(t, stdout, "Uncommitted changes")
+	assert.NotContains(t, stdout, "dot sync --push")
+}
+
+func TestSyncCommand_PushRoundTrip(t *testing.T) {
+	sandbox := newSyncSandbox(t)
+	manageInSandbox(t, "dot-vim")
+
+	require.NoError(t, os.WriteFile(filepath.Join(sandbox.packageDir, "dot-vim", "dot-vimrc"), []byte("set number\nset ruler\n"), 0o644))
+
+	stdout, _, err := runSyncCommand(t, "--push")
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "Committed")
+	assert.Contains(t, stdout, "Pushed")
+
+	verify := sandbox.cloneOrigin(t, "verify")
+	content, err := os.ReadFile(filepath.Join(verify, "dot-vim", "dot-vimrc"))
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "set ruler")
+
+	subject := gitInDir(t, verify, "log", "-1", "--pretty=%s")
+	assert.Contains(t, subject, "local edits (dot-vim)")
+	assert.True(t, strings.HasPrefix(strings.TrimSpace(subject), "sync: "), "subject was %q", subject)
+}
+
+func TestSyncCommand_PushWithCleanTree(t *testing.T) {
+	newSyncSandbox(t)
+	manageInSandbox(t, "dot-vim")
+
+	stdout, _, err := runSyncCommand(t, "--push")
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "Nothing to commit")
+	assert.NotContains(t, stdout, "Pushed")
+}
+
+func TestSyncCommand_RebaseConflictStops(t *testing.T) {
+	sandbox := newSyncSandbox(t)
+	manageInSandbox(t, "dot-vim")
+
+	sandbox.publish(t, "dot-vim/dot-vimrc", "remote change\n", "feat(vim): remote change")
+
+	require.NoError(t, os.WriteFile(filepath.Join(sandbox.packageDir, "dot-vim", "dot-vimrc"), []byte("local change\n"), 0o644))
+	gitInDir(t, sandbox.packageDir, "commit", "-am", "feat(vim): local change")
+
+	_, stderr, err := runSyncCommand(t)
+	require.Error(t, err)
+
+	assert.Contains(t, stderr, "dot-vim/dot-vimrc")
+	assert.Contains(t, stderr, sandbox.packageDir)
+	assert.Contains(t, stderr, "dot sync")
+}
+
+func TestSyncCommand_NotAGitRepository(t *testing.T) {
+	requireGitBinary(t)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+
+	plain := t.TempDir()
+	setupIntegrationTestFlags(t, CLIFlags{
+		packageDir: plain,
+		targetDir:  t.TempDir(),
+	})
+
+	_, _, err := runSyncCommand(t)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a git repository")
+	assert.Contains(t, err.Error(), plain)
+}
+
+func TestSyncCommand_RejectsPositionalArguments(t *testing.T) {
+	newSyncSandbox(t)
+
+	_, _, err := runSyncCommand(t, "dot-vim")
+	require.Error(t, err)
+}
+
+func TestSyncCommand_DryRunSkipsGitWrites(t *testing.T) {
+	sandbox := newSyncSandbox(t)
+	manageInSandbox(t, "dot-vim")
+	sandbox.publish(t, "dot-vim/dot-vimrc", "set number\nset ruler\n", "feat(vim): enable ruler")
+
+	cliFlags.dryRun = true
+	t.Cleanup(func() { cliFlags.dryRun = false })
+
+	stdout, _, err := runSyncCommand(t)
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "Dry run")
+
+	content, err := os.ReadFile(filepath.Join(sandbox.packageDir, "dot-vim", "dot-vimrc"))
+	require.NoError(t, err)
+	assert.NotContains(t, string(content), "set ruler", "dry run does not pull")
+}
+
+func TestNewSyncCommand_Metadata(t *testing.T) {
+	cmd := newSyncCommand()
+
+	assert.Equal(t, "sync", cmd.Name())
+	assert.NotEmpty(t, cmd.Short)
+	assert.NotNil(t, cmd.Flags().Lookup("push"))
+}

--- a/cmd/dot/testdata/golden/errors/help_invalid_command.golden
+++ b/cmd/dot/testdata/golden/errors/help_invalid_command.golden
@@ -13,6 +13,7 @@ Available Commands:
   manage      Install packages by creating symlinks
   remanage    Reinstall packages with incremental updates
   status      Show installation status for packages
+  sync        Reconcile this machine with the dotfiles repository
   unmanage    Remove packages by deleting symlinks
   upgrade     Upgrade dot to the latest version
 

--- a/cmd/dot/testdata/golden/errors/invalid_flag.golden
+++ b/cmd/dot/testdata/golden/errors/invalid_flag.golden
@@ -12,6 +12,7 @@ Available Commands:
   manage      Install packages by creating symlinks
   remanage    Reinstall packages with incremental updates
   status      Show installation status for packages
+  sync        Reconcile this machine with the dotfiles repository
   unmanage    Remove packages by deleting symlinks
   upgrade     Upgrade dot to the latest version
 

--- a/docs/user/05-commands.md
+++ b/docs/user/05-commands.md
@@ -728,8 +728,10 @@ executable, so it uses your existing remotes, credentials, and hooks.
 **Workflow**:
 1. Runs `git pull --rebase --autostash` in the package directory and reports
    the commits gained
-2. Remanages every package in the manifest, so files added or removed
-   upstream are linked or unlinked on this machine
+2. Remanages every manifest package that still exists in the package
+   directory, so files added or removed upstream are linked or unlinked on
+   this machine. A package deleted upstream is reported, not remanaged, and
+   does not stop the rest of the run
 3. Prints a health summary: how many packages are healthy out of the total
 4. Lists uncommitted local changes grouped by package, or prints nothing extra
    when the tree is clean
@@ -800,6 +802,9 @@ Common errors and solutions:
   binary
 - **Push rejected**: The remote moved ahead. Run `dot sync` again to rebase,
   then `dot sync --push`
+- **Package in the manifest missing from the package directory**: Another
+  machine deleted the package. Run `dot unmanage PACKAGE` to remove its
+  leftover links
 
 **Exit Codes**:
 - `0`: Success

--- a/docs/user/05-commands.md
+++ b/docs/user/05-commands.md
@@ -698,6 +698,118 @@ This ensures adopted directories aren't converted to managed packages.
 - `0`: Success, changes applied or no changes needed
 - `1`: Error during operation
 
+### sync
+
+Reconcile this machine with the dotfiles repository.
+
+**Synopsis**:
+```bash
+dot sync [options]
+```
+
+**Arguments**: None. `sync` always operates on every package recorded in the
+manifest.
+
+**Options**:
+- `--push`: Commit and push local changes after syncing
+
+All global options also apply.
+
+**Description**:
+
+`sync` is the single verb for multi-machine work. It replaces the manual
+`git pull` plus `dot remanage` sequence, and it covers the direction that
+sequence misses: edits made through a symlink land in the package directory
+and leave the repository dirty, with nothing to surface them.
+
+The package directory must be a git repository. `sync` runs the system `git`
+executable, so it uses your existing remotes, credentials, and hooks.
+
+**Workflow**:
+1. Runs `git pull --rebase --autostash` in the package directory and reports
+   the commits gained
+2. Remanages every package in the manifest, so files added or removed
+   upstream are linked or unlinked on this machine
+3. Prints a health summary: how many packages are healthy out of the total
+4. Lists uncommitted local changes grouped by package, or prints nothing extra
+   when the tree is clean
+5. With `--push`, commits every working-tree change and pushes it
+
+**Commit Message Format**:
+
+`--push` stages all changes and commits them with:
+
+```
+sync: <short-hostname> local edits (<packages>)
+```
+
+For example, `sync: zeus local edits (dot-vim, dot-zsh)`. Commit hooks run
+normally; `sync` never passes `--no-verify`.
+
+**Examples**:
+
+```bash
+# Pull, relink, and report local state
+dot sync
+
+# Same, then commit and push local edits
+dot sync --push
+
+# Preview without touching git
+dot --dry-run sync
+
+# Sync a repository that is not the current directory
+dot --dir ~/dotfiles sync
+```
+
+**Sample Output**:
+
+```text
+✓ Pulled 2 commits
+  • 86de286 feat(vim): add solarized colors
+  • 1c4b9f2 fix(zsh): correct PATH order
+✓ Remanaged 3 packages
+ℹ Packages: 3/3 healthy
+⚠ Uncommitted changes in /home/user/dotfiles
+  dot-vim
+     M dot-vim/dot-vimrc
+  Run 'dot sync --push' to commit and push, or commit manually.
+```
+
+**Rebase Conflicts**:
+
+If the rebase stops with conflicts, `sync` prints the conflicted paths and
+exits non-zero without attempting to resolve them:
+
+```text
+✗ Rebase stopped with conflicts
+  • dot-vim/dot-vimrc
+  Resolve the conflicts in /home/user/dotfiles, then run 'dot sync' again.
+```
+
+Resolve the conflicts in the package directory with your usual git tools
+(`git status`, `git add`, `git rebase --continue`), then run `dot sync` again.
+
+**Error Handling**:
+
+Common errors and solutions:
+
+- **Package directory is not a git repository**: Point `--dir` at your
+  dotfiles clone, or initialize one with `git init`
+- **git executable not found**: Install git; `sync` shells out to the system
+  binary
+- **Push rejected**: The remote moved ahead. Run `dot sync` again to rebase,
+  then `dot sync --push`
+
+**Exit Codes**:
+- `0`: Success
+- `1`: Error, including a rebase stopped by conflicts
+
+**Related Commands**:
+- `remanage`: Relink a specific package without touching git
+- `status`: Inspect installation state without pulling
+- `clone`: First-time setup on a new machine
+
 ### adopt
 
 Move existing files or directories into a package and create symlinks.

--- a/docs/user/06-workflows.md
+++ b/docs/user/06-workflows.md
@@ -62,22 +62,96 @@ dot status
 
 ### Keeping Machines in Sync
 
-On machine with changes:
+`dot sync` is the single verb for day-to-day multi-machine work. Run it in
+the package directory (or point `--dir` at it):
+
 ```bash
-cd ~/dotfiles
-vim dot-vim/dot-vimrc
-dot remanage dot-vim
-git add dot-vim/
-git commit -m "feat(vim): update configuration"
-git push
+dot sync
 ```
 
-On other machines:
+One run does four things:
+
+1. `git pull --rebase --autostash`, reporting the commits gained
+2. Remanages every package in the manifest, so files added or removed
+   upstream are linked or unlinked here
+3. Prints how many packages are healthy
+4. Lists uncommitted local edits, grouped by package
+
+Step 4 is the half that a bare `git pull` misses. Because your editor writes
+through the symlink, every edit to a managed file lands in the package
+directory and leaves the repository dirty. Nothing announces that, so changes
+sit unpushed until the next machine notices they are missing.
+
+**Outbound: publishing local edits**
+
+```bash
+# Edit through the symlink as usual
+vim ~/.vimrc
+
+# Review, relink, and publish in one step
+dot sync --push
+```
+
+`--push` stages every working-tree change and commits it as
+`sync: <short-hostname> local edits (<packages>)`, for example
+`sync: zeus local edits (dot-vim)`, then pushes. Commit hooks run normally.
+When there is nothing to commit, `sync` says so and does not push.
+
+For a hand-written message, commit yourself and let `sync` handle the rest:
+
 ```bash
 cd ~/dotfiles
-git pull
-dot remanage dot-vim dot-zsh dot-tmux
+git add dot-vim/
+git commit -m "feat(vim): enable ruler"
+dot sync --push
 ```
+
+**Inbound: picking up other machines' changes**
+
+```bash
+dot sync
+```
+
+Content-only changes arrive through the symlinks with no relinking at all.
+Structural changes (a new file in a package, a deleted one) are applied by the
+remanage step, so no separate `dot remanage` call is needed.
+
+**When the rebase conflicts**
+
+`sync` stops, prints the conflicted paths, and exits non-zero. It never tries
+to resolve anything:
+
+```text
+✗ Rebase stopped with conflicts
+  • dot-vim/dot-vimrc
+  Resolve the conflicts in /home/user/dotfiles, then run 'dot sync' again.
+```
+
+Resolve them in the package directory with your usual git tools, then rerun:
+
+```bash
+cd ~/dotfiles
+vim dot-vim/dot-vimrc      # resolve markers
+git add dot-vim/dot-vimrc
+git rebase --continue
+dot sync
+```
+
+**Manual git fallback**
+
+`sync` shells out to the system `git`, so nothing stops you from driving the
+repository yourself. The equivalent sequence is:
+
+```bash
+cd ~/dotfiles
+git pull --rebase --autostash
+dot remanage dot-vim dot-zsh dot-tmux   # relink structural changes
+git status                              # look for local edits to publish
+```
+
+Use the manual route for anything `sync` deliberately does not do: switching
+branches, rewriting history, partial commits, or pushing to a different
+remote.
 
 ## Conflict Resolution
 

--- a/docs/user/06-workflows.md
+++ b/docs/user/06-workflows.md
@@ -112,9 +112,20 @@ dot sync --push
 dot sync
 ```
 
-Content-only changes arrive through the symlinks with no relinking at all.
-Structural changes (a new file in a package, a deleted one) are applied by the
-remanage step, so no separate `dot remanage` call is needed.
+Content-only changes are already live the moment the pull lands, because the
+symlinks point at the files git just rewrote. Structural changes (a new file in
+a package, a deleted one) are applied by the remanage step, so no separate
+`dot remanage` call is needed. The remanage step runs either way and reports
+what it touched; only a pull that changed nothing at all stays silent.
+
+A package that another machine deleted cannot be relinked. `sync` names it,
+points at `dot unmanage`, and carries on with the rest of the run:
+
+```text
+⚠ 1 package in the manifest missing from the package directory
+  dot-vim
+  Run 'dot unmanage dot-vim' to remove the leftover links.
+```
 
 **When the rebase conflicts**
 

--- a/internal/gitsync/errors.go
+++ b/internal/gitsync/errors.go
@@ -1,0 +1,60 @@
+package gitsync
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ErrGitNotFound reports that the git executable is not installed or not on PATH.
+type ErrGitNotFound struct {
+	Err error
+}
+
+func (e ErrGitNotFound) Error() string {
+	return "git executable not found in PATH: dot sync requires a working git installation"
+}
+
+func (e ErrGitNotFound) Unwrap() error {
+	return e.Err
+}
+
+// ErrNotRepository reports that a directory is not inside a git working tree.
+type ErrNotRepository struct {
+	Dir string
+}
+
+func (e ErrNotRepository) Error() string {
+	return fmt.Sprintf("package directory is not a git repository: %s", e.Dir)
+}
+
+// ErrRebaseConflict reports that `git pull --rebase` stopped with conflicts.
+// Paths lists the conflicted files relative to the repository root.
+type ErrRebaseConflict struct {
+	Dir    string
+	Paths  []string
+	Output string
+}
+
+func (e ErrRebaseConflict) Error() string {
+	return fmt.Sprintf("rebase stopped with conflicts in %s: %s", e.Dir, strings.Join(e.Paths, ", "))
+}
+
+// ErrCommand reports a git invocation that exited non-zero or failed to start.
+type ErrCommand struct {
+	Args     []string
+	ExitCode int
+	Stderr   string
+	Err      error
+}
+
+func (e ErrCommand) Error() string {
+	msg := fmt.Sprintf("git %s failed with exit code %d", strings.Join(e.Args, " "), e.ExitCode)
+	if e.Stderr != "" {
+		msg = fmt.Sprintf("%s: %s", msg, e.Stderr)
+	}
+	return msg
+}
+
+func (e ErrCommand) Unwrap() error {
+	return e.Err
+}

--- a/internal/gitsync/errors.go
+++ b/internal/gitsync/errors.go
@@ -33,10 +33,16 @@ type ErrRebaseConflict struct {
 	Dir    string
 	Paths  []string
 	Output string
+	// Err is the failing git invocation, kept so callers can inspect it.
+	Err error
 }
 
 func (e ErrRebaseConflict) Error() string {
 	return fmt.Sprintf("rebase stopped with conflicts in %s: %s", e.Dir, strings.Join(e.Paths, ", "))
+}
+
+func (e ErrRebaseConflict) Unwrap() error {
+	return e.Err
 }
 
 // ErrCommand reports a git invocation that exited non-zero or failed to start.

--- a/internal/gitsync/repo.go
+++ b/internal/gitsync/repo.go
@@ -1,0 +1,250 @@
+// Package gitsync wraps the system git executable with the small set of
+// operations dot needs to reconcile a package directory with its remote:
+// rebasing pulls, working-tree inspection, and commit and push of local edits.
+package gitsync
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+)
+
+// Output holds the captured result of a git invocation.
+type Output struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+// Combined returns stdout and stderr joined, in that order, skipping empties.
+func (o Output) Combined() string {
+	parts := make([]string, 0, 2)
+	if o.Stdout != "" {
+		parts = append(parts, o.Stdout)
+	}
+	if o.Stderr != "" {
+		parts = append(parts, o.Stderr)
+	}
+	return strings.Join(parts, "\n")
+}
+
+// Runner executes a git subcommand in a working directory.
+type Runner interface {
+	Run(ctx context.Context, dir string, args ...string) (Output, error)
+}
+
+// ExecRunner runs git through os/exec.
+type ExecRunner struct {
+	// GitPath is the resolved path to the git executable.
+	GitPath string
+	// Env overrides the environment passed to git. A nil Env inherits the
+	// process environment.
+	Env []string
+}
+
+// NewExecRunner locates git on PATH and returns a runner for it.
+// It returns ErrGitNotFound when git is not installed.
+func NewExecRunner() (*ExecRunner, error) {
+	path, err := exec.LookPath("git")
+	if err != nil {
+		return nil, ErrGitNotFound{Err: err}
+	}
+	return &ExecRunner{GitPath: path}, nil
+}
+
+// Run executes git with the given arguments in dir and captures its output.
+// Trailing newlines are trimmed from both streams.
+func (r *ExecRunner) Run(ctx context.Context, dir string, args ...string) (Output, error) {
+	cmd := exec.CommandContext(ctx, r.GitPath, args...) // #nosec G204 -- arguments are constructed by dot, not user input
+	cmd.Dir = dir
+	if r.Env != nil {
+		cmd.Env = r.Env
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	out := Output{
+		Stdout:   strings.TrimRight(stdout.String(), "\n"),
+		Stderr:   strings.TrimRight(stderr.String(), "\n"),
+		ExitCode: cmd.ProcessState.ExitCode(),
+	}
+	if err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			out.ExitCode = -1
+		}
+		return out, ErrCommand{
+			Args:     args,
+			ExitCode: out.ExitCode,
+			Stderr:   out.Stderr,
+			Err:      err,
+		}
+	}
+
+	return out, nil
+}
+
+// Commit is a single commit summary produced by a pull.
+type Commit struct {
+	Hash    string
+	Subject string
+}
+
+// PullResult describes the effect of a rebasing pull.
+type PullResult struct {
+	OldHead string
+	NewHead string
+	// Commits are the commits reachable from the new head but not the old
+	// one, newest first.
+	Commits []Commit
+}
+
+// UpToDate reports whether the pull left the branch unchanged.
+func (r PullResult) UpToDate() bool {
+	return len(r.Commits) == 0
+}
+
+// Repo is a git working tree that dot manages.
+type Repo struct {
+	dir    string
+	runner Runner
+}
+
+// NewRepo returns a Repo for dir that uses the given runner.
+func NewRepo(dir string, runner Runner) *Repo {
+	return &Repo{dir: dir, runner: runner}
+}
+
+// Open returns a Repo for dir backed by the system git executable.
+func Open(dir string) (*Repo, error) {
+	runner, err := NewExecRunner()
+	if err != nil {
+		return nil, err
+	}
+	return NewRepo(dir, runner), nil
+}
+
+// Dir returns the working directory the repository operates on.
+func (r *Repo) Dir() string {
+	return r.dir
+}
+
+// EnsureRepository verifies that the directory is inside a git working tree.
+func (r *Repo) EnsureRepository(ctx context.Context) error {
+	out, err := r.runner.Run(ctx, r.dir, "rev-parse", "--is-inside-work-tree")
+	if err != nil || strings.TrimSpace(out.Stdout) != "true" {
+		return ErrNotRepository{Dir: r.dir}
+	}
+	return nil
+}
+
+// Head returns the current commit hash.
+func (r *Repo) Head(ctx context.Context) (string, error) {
+	out, err := r.runner.Run(ctx, r.dir, "rev-parse", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.Stdout), nil
+}
+
+// Pull runs `git pull --rebase --autostash` and reports the commits gained.
+// It returns ErrRebaseConflict when the rebase stops with conflicting paths;
+// callers are expected to stop and let the user resolve them by hand.
+func (r *Repo) Pull(ctx context.Context) (PullResult, error) {
+	oldHead, _ := r.Head(ctx)
+
+	out, err := r.runner.Run(ctx, r.dir, "pull", "--rebase", "--autostash")
+	if err != nil {
+		if paths := r.conflictedPaths(ctx); len(paths) > 0 {
+			return PullResult{}, ErrRebaseConflict{
+				Dir:    r.dir,
+				Paths:  paths,
+				Output: out.Combined(),
+			}
+		}
+		return PullResult{}, err
+	}
+
+	newHead, headErr := r.Head(ctx)
+	if headErr != nil {
+		return PullResult{}, headErr
+	}
+
+	commits, err := r.commitsBetween(ctx, oldHead, newHead)
+	if err != nil {
+		return PullResult{}, err
+	}
+
+	return PullResult{OldHead: oldHead, NewHead: newHead, Commits: commits}, nil
+}
+
+// Status returns the working-tree entries reported by git status --porcelain.
+func (r *Repo) Status(ctx context.Context) ([]StatusEntry, error) {
+	out, err := r.runner.Run(ctx, r.dir, "status", "--porcelain")
+	if err != nil {
+		return nil, err
+	}
+	return ParsePorcelain(out.Stdout), nil
+}
+
+// CommitAll stages every change in the working tree and commits it.
+// Commit hooks run normally; dot never bypasses them.
+func (r *Repo) CommitAll(ctx context.Context, message string) error {
+	if _, err := r.runner.Run(ctx, r.dir, "add", "--all"); err != nil {
+		return err
+	}
+	_, err := r.runner.Run(ctx, r.dir, "commit", "-m", message)
+	return err
+}
+
+// Push publishes the current branch to its configured remote.
+func (r *Repo) Push(ctx context.Context) error {
+	_, err := r.runner.Run(ctx, r.dir, "push")
+	return err
+}
+
+// conflictedPaths returns the unmerged paths in the working tree, if any.
+func (r *Repo) conflictedPaths(ctx context.Context) []string {
+	out, err := r.runner.Run(ctx, r.dir, "diff", "--name-only", "--diff-filter=U")
+	if err != nil {
+		return nil
+	}
+
+	paths := make([]string, 0)
+	for _, line := range strings.Split(out.Stdout, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			paths = append(paths, line)
+		}
+	}
+	return paths
+}
+
+// commitsBetween lists the commits reachable from newHead but not oldHead.
+// After a rebase this includes locally rewritten commits, which are new to
+// this branch as well.
+func (r *Repo) commitsBetween(ctx context.Context, oldHead, newHead string) ([]Commit, error) {
+	if oldHead == "" || oldHead == newHead {
+		return nil, nil
+	}
+
+	out, err := r.runner.Run(ctx, r.dir, "log", "--pretty=format:%h\t%s", oldHead+".."+newHead)
+	if err != nil {
+		return nil, err
+	}
+
+	commits := make([]Commit, 0)
+	for _, line := range strings.Split(out.Stdout, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		hash, subject, _ := strings.Cut(line, "\t")
+		commits = append(commits, Commit{Hash: hash, Subject: subject})
+	}
+	return commits, nil
+}

--- a/internal/gitsync/repo.go
+++ b/internal/gitsync/repo.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -135,28 +136,77 @@ func (r *Repo) Dir() string {
 }
 
 // EnsureRepository verifies that the directory is inside a git working tree.
+// It reports ErrNotRepository only when git says so, or when the directory
+// does not exist; any other git failure (a broken installation, a permissions
+// problem, a rejected repository) is returned unchanged.
 func (r *Repo) EnsureRepository(ctx context.Context) error {
 	out, err := r.runner.Run(ctx, r.dir, "rev-parse", "--is-inside-work-tree")
-	if err != nil || strings.TrimSpace(out.Stdout) != "true" {
+	switch {
+	case err == nil && strings.TrimSpace(out.Stdout) == "true":
+		return nil
+	case err == nil:
+		// git answered, but the directory is not a working tree (a bare repo).
 		return ErrNotRepository{Dir: r.dir}
+	case isNotRepositoryErr(err), !dirExists(r.dir):
+		return ErrNotRepository{Dir: r.dir}
+	default:
+		return err
 	}
-	return nil
 }
 
-// Head returns the current commit hash.
+// isNotRepositoryErr reports whether a failed git invocation failed because the
+// directory is outside a git working tree.
+func isNotRepositoryErr(err error) bool {
+	var cmdErr ErrCommand
+	if !errors.As(err, &cmdErr) {
+		return false
+	}
+	stderr := strings.ToLower(cmdErr.Stderr)
+	return strings.Contains(stderr, "not a git repository") ||
+		strings.Contains(stderr, "not a working tree")
+}
+
+// dirExists reports whether path is an existing directory.
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+// Head returns the current commit hash. A repository whose HEAD is unborn,
+// meaning it has no commits yet, reports an empty hash and no error.
 func (r *Repo) Head(ctx context.Context) (string, error) {
 	out, err := r.runner.Run(ctx, r.dir, "rev-parse", "HEAD")
 	if err != nil {
+		if isUnbornHeadErr(err) {
+			return "", nil
+		}
 		return "", err
 	}
 	return strings.TrimSpace(out.Stdout), nil
+}
+
+// isUnbornHeadErr reports whether a failed rev-parse failed because HEAD points
+// at a branch that has no commits yet.
+func isUnbornHeadErr(err error) bool {
+	var cmdErr ErrCommand
+	if !errors.As(err, &cmdErr) {
+		return false
+	}
+	stderr := strings.ToLower(cmdErr.Stderr)
+	return strings.Contains(stderr, "unknown revision") ||
+		strings.Contains(stderr, "ambiguous argument 'head'")
 }
 
 // Pull runs `git pull --rebase --autostash` and reports the commits gained.
 // It returns ErrRebaseConflict when the rebase stops with conflicting paths;
 // callers are expected to stop and let the user resolve them by hand.
 func (r *Repo) Pull(ctx context.Context) (PullResult, error) {
-	oldHead, _ := r.Head(ctx)
+	// An empty oldHead means the branch was unborn: every commit the pull
+	// brings in is new to this working tree.
+	oldHead, err := r.Head(ctx)
+	if err != nil {
+		return PullResult{}, err
+	}
 
 	out, err := r.runner.Run(ctx, r.dir, "pull", "--rebase", "--autostash")
 	if err != nil {
@@ -165,6 +215,7 @@ func (r *Repo) Pull(ctx context.Context) (PullResult, error) {
 				Dir:    r.dir,
 				Paths:  paths,
 				Output: out.Combined(),
+				Err:    err,
 			}
 		}
 		return PullResult{}, err
@@ -227,13 +278,19 @@ func (r *Repo) conflictedPaths(ctx context.Context) []string {
 
 // commitsBetween lists the commits reachable from newHead but not oldHead.
 // After a rebase this includes locally rewritten commits, which are new to
-// this branch as well.
+// this branch as well. An empty oldHead means the branch was unborn before the
+// pull, so the whole imported history counts as new.
 func (r *Repo) commitsBetween(ctx context.Context, oldHead, newHead string) ([]Commit, error) {
-	if oldHead == "" || oldHead == newHead {
+	if newHead == "" || oldHead == newHead {
 		return nil, nil
 	}
 
-	out, err := r.runner.Run(ctx, r.dir, "log", "--pretty=format:%h\t%s", oldHead+".."+newHead)
+	revisions := newHead
+	if oldHead != "" {
+		revisions = oldHead + ".." + newHead
+	}
+
+	out, err := r.runner.Run(ctx, r.dir, "log", "--pretty=format:%h\t%s", revisions)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gitsync/repo_test.go
+++ b/internal/gitsync/repo_test.go
@@ -1,0 +1,290 @@
+package gitsync
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// requireGit skips the test when git is not installed on the machine.
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+}
+
+// runGit runs a git command in dir and fails the test when it errors.
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = gitEnv(t)
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %v failed: %s", args, out)
+	return string(out)
+}
+
+// gitEnv returns a hermetic environment for git invocations in tests.
+func gitEnv(t *testing.T) []string {
+	t.Helper()
+	home := t.TempDir()
+	return append(os.Environ(),
+		"HOME="+home,
+		"XDG_CONFIG_HOME="+filepath.Join(home, "config"),
+		"GIT_CONFIG_GLOBAL="+filepath.Join(home, "gitconfig"),
+		"GIT_CONFIG_SYSTEM="+filepath.Join(home, "gitconfig-system"),
+		"GIT_AUTHOR_NAME=dot test",
+		"GIT_AUTHOR_EMAIL=dot@example.test",
+		"GIT_COMMITTER_NAME=dot test",
+		"GIT_COMMITTER_EMAIL=dot@example.test",
+	)
+}
+
+// configureRepo applies the local settings needed for hermetic commits.
+func configureRepo(t *testing.T, dir string) {
+	t.Helper()
+	runGit(t, dir, "config", "user.name", "dot test")
+	runGit(t, dir, "config", "user.email", "dot@example.test")
+	runGit(t, dir, "config", "commit.gpgsign", "false")
+	runGit(t, dir, "config", "core.hooksPath", t.TempDir())
+}
+
+// newOriginWithClone creates a bare origin repo seeded with one package and
+// returns the origin path plus a working clone path.
+func newOriginWithClone(t *testing.T) (origin, clone string) {
+	t.Helper()
+	requireGit(t)
+
+	root := t.TempDir()
+	origin = filepath.Join(root, "origin.git")
+	seed := filepath.Join(root, "seed")
+	clone = filepath.Join(root, "clone")
+
+	require.NoError(t, os.MkdirAll(origin, 0o755))
+	runGit(t, origin, "init", "--bare", "-b", "main")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(seed, "dot-vim"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(seed, "dot-vim", "dot-vimrc"), []byte("set number\n"), 0o644))
+	runGit(t, seed, "init", "-b", "main")
+	configureRepo(t, seed)
+	runGit(t, seed, "add", ".")
+	runGit(t, seed, "commit", "-m", "seed: initial packages")
+	runGit(t, seed, "remote", "add", "origin", origin)
+	runGit(t, seed, "push", "-u", "origin", "main")
+
+	runGit(t, root, "clone", origin, clone)
+	configureRepo(t, clone)
+
+	return origin, clone
+}
+
+// openTestRepo opens a Repo whose git invocations use the hermetic test env.
+func openTestRepo(t *testing.T, dir string) *Repo {
+	t.Helper()
+	runner, err := NewExecRunner()
+	require.NoError(t, err)
+	runner.Env = gitEnv(t)
+	return NewRepo(dir, runner)
+}
+
+func TestExecRunner_RunCapturesOutput(t *testing.T) {
+	requireGit(t)
+	_, clone := newOriginWithClone(t)
+
+	runner, err := NewExecRunner()
+	require.NoError(t, err)
+	runner.Env = gitEnv(t)
+
+	out, err := runner.Run(context.Background(), clone, "rev-parse", "--abbrev-ref", "HEAD")
+	require.NoError(t, err)
+	assert.Equal(t, "main", out.Stdout)
+}
+
+func TestExecRunner_RunReturnsCommandError(t *testing.T) {
+	requireGit(t)
+	_, clone := newOriginWithClone(t)
+
+	runner, err := NewExecRunner()
+	require.NoError(t, err)
+	runner.Env = gitEnv(t)
+
+	_, err = runner.Run(context.Background(), clone, "rev-parse", "--verify", "does-not-exist")
+	require.Error(t, err)
+
+	var cmdErr ErrCommand
+	require.ErrorAs(t, err, &cmdErr)
+	assert.NotZero(t, cmdErr.ExitCode)
+	assert.Contains(t, cmdErr.Error(), "git rev-parse")
+}
+
+func TestRepo_EnsureRepository(t *testing.T) {
+	requireGit(t)
+	_, clone := newOriginWithClone(t)
+
+	t.Run("git repository passes", func(t *testing.T) {
+		repo := openTestRepo(t, clone)
+		require.NoError(t, repo.EnsureRepository(context.Background()))
+	})
+
+	t.Run("plain directory reports not a repository", func(t *testing.T) {
+		plain := t.TempDir()
+		repo := openTestRepo(t, plain)
+
+		err := repo.EnsureRepository(context.Background())
+		require.Error(t, err)
+
+		var notRepo ErrNotRepository
+		require.ErrorAs(t, err, &notRepo)
+		assert.Equal(t, plain, notRepo.Dir)
+		assert.Contains(t, err.Error(), plain)
+	})
+
+	t.Run("missing directory reports not a repository", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "nope")
+		repo := openTestRepo(t, missing)
+
+		var notRepo ErrNotRepository
+		require.ErrorAs(t, repo.EnsureRepository(context.Background()), &notRepo)
+	})
+}
+
+func TestRepo_PullReportsNewCommits(t *testing.T) {
+	requireGit(t)
+	origin, clone := newOriginWithClone(t)
+
+	// Second clone publishes a new commit.
+	other := filepath.Join(t.TempDir(), "other")
+	runGit(t, filepath.Dir(other), "clone", origin, other)
+	configureRepo(t, other)
+	require.NoError(t, os.WriteFile(filepath.Join(other, "dot-vim", "dot-vimrc"), []byte("set number\nset ruler\n"), 0o644))
+	runGit(t, other, "commit", "-am", "feat(vim): enable ruler")
+	runGit(t, other, "push")
+
+	repo := openTestRepo(t, clone)
+	result, err := repo.Pull(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, result.Commits, 1)
+	assert.Equal(t, "feat(vim): enable ruler", result.Commits[0].Subject)
+	assert.NotEmpty(t, result.Commits[0].Hash)
+	assert.NotEqual(t, result.OldHead, result.NewHead)
+
+	content, err := os.ReadFile(filepath.Join(clone, "dot-vim", "dot-vimrc"))
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "set ruler")
+}
+
+func TestRepo_PullUpToDateReportsNoCommits(t *testing.T) {
+	requireGit(t)
+	_, clone := newOriginWithClone(t)
+
+	repo := openTestRepo(t, clone)
+	result, err := repo.Pull(context.Background())
+	require.NoError(t, err)
+
+	assert.Empty(t, result.Commits)
+	assert.Equal(t, result.OldHead, result.NewHead)
+}
+
+func TestRepo_PullConflictReportsPaths(t *testing.T) {
+	requireGit(t)
+	origin, clone := newOriginWithClone(t)
+
+	other := filepath.Join(t.TempDir(), "other")
+	runGit(t, filepath.Dir(other), "clone", origin, other)
+	configureRepo(t, other)
+	require.NoError(t, os.WriteFile(filepath.Join(other, "dot-vim", "dot-vimrc"), []byte("remote change\n"), 0o644))
+	runGit(t, other, "commit", "-am", "feat(vim): remote change")
+	runGit(t, other, "push")
+
+	// Local commit touching the same line causes a rebase conflict.
+	require.NoError(t, os.WriteFile(filepath.Join(clone, "dot-vim", "dot-vimrc"), []byte("local change\n"), 0o644))
+	runGit(t, clone, "commit", "-am", "feat(vim): local change")
+
+	repo := openTestRepo(t, clone)
+	_, err := repo.Pull(context.Background())
+	require.Error(t, err)
+
+	var conflict ErrRebaseConflict
+	require.ErrorAs(t, err, &conflict)
+	assert.Contains(t, conflict.Paths, "dot-vim/dot-vimrc")
+	assert.Contains(t, conflict.Error(), "dot-vim/dot-vimrc")
+}
+
+func TestRepo_StatusReportsWorkingTree(t *testing.T) {
+	requireGit(t)
+	_, clone := newOriginWithClone(t)
+	repo := openTestRepo(t, clone)
+	ctx := context.Background()
+
+	entries, err := repo.Status(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "freshly cloned tree is clean")
+
+	require.NoError(t, os.WriteFile(filepath.Join(clone, "dot-vim", "dot-vimrc"), []byte("edited\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(clone, "dot-zsh"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(clone, "dot-zsh", "dot-zshrc"), []byte("new\n"), 0o644))
+
+	entries, err = repo.Status(ctx)
+	require.NoError(t, err)
+
+	groups := GroupByPackage(entries)
+	require.Len(t, groups, 2)
+	assert.Equal(t, "dot-vim", groups[0].Package)
+	assert.Equal(t, "dot-zsh", groups[1].Package)
+}
+
+func TestRepo_CommitAllAndPush(t *testing.T) {
+	requireGit(t)
+	origin, clone := newOriginWithClone(t)
+	repo := openTestRepo(t, clone)
+	ctx := context.Background()
+
+	require.NoError(t, os.WriteFile(filepath.Join(clone, "dot-vim", "dot-vimrc"), []byte("edited\n"), 0o644))
+
+	require.NoError(t, repo.CommitAll(ctx, "sync: testhost local edits (dot-vim)"))
+	require.NoError(t, repo.Push(ctx))
+
+	entries, err := repo.Status(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+
+	// The commit is visible from an independent clone.
+	verify := filepath.Join(t.TempDir(), "verify")
+	runGit(t, filepath.Dir(verify), "clone", origin, verify)
+	content, err := os.ReadFile(filepath.Join(verify, "dot-vim", "dot-vimrc"))
+	require.NoError(t, err)
+	assert.Equal(t, "edited\n", string(content))
+
+	log := runGit(t, verify, "log", "-1", "--pretty=%s")
+	assert.Contains(t, log, "sync: testhost local edits (dot-vim)")
+}
+
+func TestRepo_CommitAllWithNothingStagedFails(t *testing.T) {
+	requireGit(t)
+	_, clone := newOriginWithClone(t)
+	repo := openTestRepo(t, clone)
+
+	err := repo.CommitAll(context.Background(), "sync: testhost local edits")
+	require.Error(t, err)
+}
+
+func TestErrGitNotFound(t *testing.T) {
+	err := ErrGitNotFound{Err: errors.New("boom")}
+	assert.Contains(t, err.Error(), "git")
+	assert.Equal(t, "boom", errors.Unwrap(err).Error())
+}
+
+func TestErrCommand_Error(t *testing.T) {
+	err := ErrCommand{Args: []string{"status"}, ExitCode: 128, Stderr: "fatal: bad"}
+	assert.Contains(t, err.Error(), "git status")
+	assert.Contains(t, err.Error(), "fatal: bad")
+	assert.Contains(t, err.Error(), "128")
+}

--- a/internal/gitsync/repo_test.go
+++ b/internal/gitsync/repo_test.go
@@ -155,6 +155,75 @@ func TestRepo_EnsureRepository(t *testing.T) {
 	})
 }
 
+// stubRunner returns canned results, so tests can exercise git failures that
+// are awkward to provoke with a real repository.
+type stubRunner struct {
+	out Output
+	err error
+}
+
+func (r stubRunner) Run(_ context.Context, _ string, _ ...string) (Output, error) {
+	return r.out, r.err
+}
+
+func TestRepo_EnsureRepositoryPropagatesUnexpectedFailure(t *testing.T) {
+	inner := ErrCommand{
+		Args:     []string{"rev-parse", "--is-inside-work-tree"},
+		ExitCode: 128,
+		Stderr:   "fatal: detected dubious ownership in repository",
+		Err:      errors.New("exit status 128"),
+	}
+	// The directory exists, so the failure cannot be a missing package dir.
+	repo := NewRepo(t.TempDir(), stubRunner{err: inner})
+
+	err := repo.EnsureRepository(context.Background())
+	require.Error(t, err)
+
+	var notRepo ErrNotRepository
+	assert.NotErrorAs(t, err, &notRepo, "an unrelated git failure is not reported as a missing repository")
+
+	var cmdErr ErrCommand
+	require.ErrorAs(t, err, &cmdErr)
+	assert.Contains(t, cmdErr.Stderr, "dubious ownership")
+}
+
+func TestRepo_HeadOnUnbornBranch(t *testing.T) {
+	requireGit(t)
+
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	configureRepo(t, dir)
+
+	repo := openTestRepo(t, dir)
+	head, err := repo.Head(context.Background())
+	require.NoError(t, err, "an unborn HEAD is a normal state, not an error")
+	assert.Empty(t, head)
+}
+
+func TestRepo_PullIntoUnbornBranchReportsEveryCommit(t *testing.T) {
+	requireGit(t)
+	origin, _ := newOriginWithClone(t)
+
+	// A repository with no commits of its own, tracking the seeded origin.
+	fresh := filepath.Join(t.TempDir(), "fresh")
+	require.NoError(t, os.MkdirAll(fresh, 0o755))
+	runGit(t, fresh, "init", "-b", "main")
+	configureRepo(t, fresh)
+	runGit(t, fresh, "remote", "add", "origin", origin)
+	runGit(t, fresh, "config", "branch.main.remote", "origin")
+	runGit(t, fresh, "config", "branch.main.merge", "refs/heads/main")
+
+	repo := openTestRepo(t, fresh)
+	result, err := repo.Pull(context.Background())
+	require.NoError(t, err)
+
+	assert.Empty(t, result.OldHead)
+	assert.NotEmpty(t, result.NewHead)
+	require.Len(t, result.Commits, 1, "the imported history counts as pulled commits")
+	assert.Equal(t, "seed: initial packages", result.Commits[0].Subject)
+	assert.False(t, result.UpToDate())
+}
+
 func TestRepo_PullReportsNewCommits(t *testing.T) {
 	requireGit(t)
 	origin, clone := newOriginWithClone(t)
@@ -216,6 +285,11 @@ func TestRepo_PullConflictReportsPaths(t *testing.T) {
 	require.ErrorAs(t, err, &conflict)
 	assert.Contains(t, conflict.Paths, "dot-vim/dot-vimrc")
 	assert.Contains(t, conflict.Error(), "dot-vim/dot-vimrc")
+
+	// The failing git invocation stays reachable for exit-code mapping.
+	var cmdErr ErrCommand
+	require.ErrorAs(t, err, &cmdErr)
+	assert.Equal(t, []string{"pull", "--rebase", "--autostash"}, cmdErr.Args)
 }
 
 func TestRepo_StatusReportsWorkingTree(t *testing.T) {

--- a/internal/gitsync/repo_test.go
+++ b/internal/gitsync/repo_test.go
@@ -359,6 +359,17 @@ func TestOpenAndDir(t *testing.T) {
 	assert.Equal(t, clone, repo.Dir())
 }
 
+func TestOpenWithoutGitOnPath(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	_, err := Open(t.TempDir())
+	require.Error(t, err)
+
+	var notFound ErrGitNotFound
+	require.ErrorAs(t, err, &notFound)
+	assert.Contains(t, err.Error(), "git")
+}
+
 func TestPullResult_UpToDate(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/gitsync/repo_test.go
+++ b/internal/gitsync/repo_test.go
@@ -276,6 +276,58 @@ func TestRepo_CommitAllWithNothingStagedFails(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestOpenAndDir(t *testing.T) {
+	requireGit(t)
+	_, clone := newOriginWithClone(t)
+
+	repo, err := Open(clone)
+	require.NoError(t, err)
+	assert.Equal(t, clone, repo.Dir())
+}
+
+func TestPullResult_UpToDate(t *testing.T) {
+	tests := []struct {
+		name   string
+		result PullResult
+		want   bool
+	}{
+		{"no commits", PullResult{OldHead: "abc", NewHead: "abc"}, true},
+		{"one commit", PullResult{Commits: []Commit{{Hash: "abc", Subject: "feat: x"}}}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.result.UpToDate())
+		})
+	}
+}
+
+func TestOutput_Combined(t *testing.T) {
+	tests := []struct {
+		name string
+		out  Output
+		want string
+	}{
+		{"both streams", Output{Stdout: "out", Stderr: "err"}, "out\nerr"},
+		{"stdout only", Output{Stdout: "out"}, "out"},
+		{"stderr only", Output{Stderr: "err"}, "err"},
+		{"neither", Output{}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.out.Combined())
+		})
+	}
+}
+
+func TestErrCommand_Unwrap(t *testing.T) {
+	inner := errors.New("exit status 1")
+	err := ErrCommand{Args: []string{"push"}, ExitCode: 1, Err: inner}
+
+	assert.ErrorIs(t, err, inner)
+}
+
 func TestErrGitNotFound(t *testing.T) {
 	err := ErrGitNotFound{Err: errors.New("boom")}
 	assert.Contains(t, err.Error(), "git")

--- a/internal/gitsync/status.go
+++ b/internal/gitsync/status.go
@@ -11,6 +11,10 @@ import (
 // the repository root rather than inside a package directory.
 const RootLabel = "(repository root)"
 
+// RootCommitToken names repository-root files inside a commit subject, where
+// the parenthesised RootLabel would read as doubled brackets.
+const RootCommitToken = "repo root"
+
 // unknownHost is the fallback used when the machine reports no usable hostname.
 const unknownHost = "unknown-host"
 
@@ -143,15 +147,6 @@ func topLevelDir(path string) string {
 	return path[:idx]
 }
 
-// PackageLabels returns the display labels of the given groups, in order.
-func PackageLabels(groups []PackageGroup) []string {
-	labels := make([]string, 0, len(groups))
-	for _, group := range groups {
-		labels = append(labels, group.Label())
-	}
-	return labels
-}
-
 // ShortHostname reduces a hostname to its first label, dropping any domain
 // suffix. It returns unknownHost when no usable label is present.
 func ShortHostname(hostname string) string {
@@ -162,11 +157,25 @@ func ShortHostname(hostname string) string {
 	return short
 }
 
+// commitLabels returns the group names for a commit subject, where
+// repository-root files are named by RootCommitToken.
+func commitLabels(groups []PackageGroup) []string {
+	labels := make([]string, 0, len(groups))
+	for _, group := range groups {
+		if group.Package == "" {
+			labels = append(labels, RootCommitToken)
+			continue
+		}
+		labels = append(labels, group.Package)
+	}
+	return labels
+}
+
 // CommitMessage builds the commit message used by `dot sync --push`.
 func CommitMessage(hostname string, groups []PackageGroup) string {
 	base := fmt.Sprintf("sync: %s local edits", ShortHostname(hostname))
 	if len(groups) == 0 {
 		return base
 	}
-	return fmt.Sprintf("%s (%s)", base, strings.Join(PackageLabels(groups), ", "))
+	return fmt.Sprintf("%s (%s)", base, strings.Join(commitLabels(groups), ", "))
 }

--- a/internal/gitsync/status.go
+++ b/internal/gitsync/status.go
@@ -1,0 +1,172 @@
+package gitsync
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// RootLabel is the display name used for changed files that live directly in
+// the repository root rather than inside a package directory.
+const RootLabel = "(repository root)"
+
+// unknownHost is the fallback used when the machine reports no usable hostname.
+const unknownHost = "unknown-host"
+
+// StatusEntry is a single line of `git status --porcelain` output.
+// Index holds the staged status code, Worktree the unstaged status code.
+// OrigPath is populated only for renames and copies.
+type StatusEntry struct {
+	Index    byte
+	Worktree byte
+	Path     string
+	OrigPath string
+}
+
+// Code returns the two-character porcelain status code, for example "??" or " M".
+func (e StatusEntry) Code() string {
+	return string([]byte{e.Index, e.Worktree})
+}
+
+// PackageGroup collects the changed entries that belong to one top-level
+// directory of the package repository. Package is empty for repository-root files.
+type PackageGroup struct {
+	Package string
+	Entries []StatusEntry
+}
+
+// Label returns the group name for display, substituting RootLabel for
+// repository-root files.
+func (g PackageGroup) Label() string {
+	if g.Package == "" {
+		return RootLabel
+	}
+	return g.Package
+}
+
+// ParsePorcelain parses `git status --porcelain` (v1) output into entries.
+// Lines that are too short to carry a status code and a path are skipped.
+func ParsePorcelain(out string) []StatusEntry {
+	entries := make([]StatusEntry, 0)
+
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if len(line) < 4 {
+			continue
+		}
+
+		entry := StatusEntry{
+			Index:    line[0],
+			Worktree: line[1],
+		}
+
+		rest := line[3:]
+		if entry.Index == 'R' || entry.Index == 'C' {
+			if orig, newPath, ok := splitRename(rest); ok {
+				entry.OrigPath = unquotePath(orig)
+				entry.Path = unquotePath(newPath)
+				entries = append(entries, entry)
+				continue
+			}
+		}
+
+		entry.Path = unquotePath(rest)
+		if entry.Path == "" {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+
+	return entries
+}
+
+// splitRename splits a porcelain rename or copy payload of the form
+// "old -> new" into its two paths.
+func splitRename(rest string) (orig, newPath string, ok bool) {
+	const arrow = " -> "
+	idx := strings.Index(rest, arrow)
+	if idx < 0 {
+		return "", "", false
+	}
+	return rest[:idx], rest[idx+len(arrow):], true
+}
+
+// unquotePath removes git's C-style quoting from a path when present.
+// Paths that fail to unquote are returned with the surrounding quotes stripped.
+func unquotePath(path string) string {
+	if !strings.HasPrefix(path, `"`) {
+		return path
+	}
+	if unquoted, err := strconv.Unquote(path); err == nil {
+		return unquoted
+	}
+	return strings.Trim(path, `"`)
+}
+
+// GroupByPackage groups entries by their top-level directory. Groups are
+// sorted by package name with repository-root files first; entries inside a
+// group are sorted by path.
+func GroupByPackage(entries []StatusEntry) []PackageGroup {
+	byPackage := make(map[string][]StatusEntry)
+	for _, entry := range entries {
+		pkg := topLevelDir(entry.Path)
+		byPackage[pkg] = append(byPackage[pkg], entry)
+	}
+
+	names := make([]string, 0, len(byPackage))
+	for name := range byPackage {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	groups := make([]PackageGroup, 0, len(names))
+	for _, name := range names {
+		grouped := byPackage[name]
+		sort.Slice(grouped, func(i, j int) bool {
+			return grouped[i].Path < grouped[j].Path
+		})
+		groups = append(groups, PackageGroup{Package: name, Entries: grouped})
+	}
+
+	return groups
+}
+
+// topLevelDir returns the first path segment of a repository-relative path,
+// or an empty string when the path names a file in the repository root.
+func topLevelDir(path string) string {
+	path = strings.TrimPrefix(path, "./")
+	idx := strings.Index(path, "/")
+	if idx < 0 {
+		return ""
+	}
+	return path[:idx]
+}
+
+// PackageLabels returns the display labels of the given groups, in order.
+func PackageLabels(groups []PackageGroup) []string {
+	labels := make([]string, 0, len(groups))
+	for _, group := range groups {
+		labels = append(labels, group.Label())
+	}
+	return labels
+}
+
+// ShortHostname reduces a hostname to its first label, dropping any domain
+// suffix. It returns unknownHost when no usable label is present.
+func ShortHostname(hostname string) string {
+	short, _, _ := strings.Cut(hostname, ".")
+	if short == "" {
+		return unknownHost
+	}
+	return short
+}
+
+// CommitMessage builds the commit message used by `dot sync --push`.
+func CommitMessage(hostname string, groups []PackageGroup) string {
+	base := fmt.Sprintf("sync: %s local edits", ShortHostname(hostname))
+	if len(groups) == 0 {
+		return base
+	}
+	return fmt.Sprintf("%s (%s)", base, strings.Join(PackageLabels(groups), ", "))
+}

--- a/internal/gitsync/status_test.go
+++ b/internal/gitsync/status_test.go
@@ -1,0 +1,281 @@
+package gitsync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePorcelain(t *testing.T) {
+	tests := []struct {
+		name  string
+		out   string
+		want  []StatusEntry
+		count int
+	}{
+		{
+			name:  "empty output",
+			out:   "",
+			want:  []StatusEntry{},
+			count: 0,
+		},
+		{
+			name:  "whitespace only",
+			out:   "\n\n",
+			want:  []StatusEntry{},
+			count: 0,
+		},
+		{
+			name: "modified tracked file",
+			out:  " M dot-vim/dot-vimrc\n",
+			want: []StatusEntry{
+				{Index: ' ', Worktree: 'M', Path: "dot-vim/dot-vimrc"},
+			},
+			count: 1,
+		},
+		{
+			name: "untracked file",
+			out:  "?? dot-tmux/dot-tmux.conf\n",
+			want: []StatusEntry{
+				{Index: '?', Worktree: '?', Path: "dot-tmux/dot-tmux.conf"},
+			},
+			count: 1,
+		},
+		{
+			name: "staged addition and deletion",
+			out:  "A  dot-zsh/dot-zshrc\n D dot-vim/colors/solarized.vim\n",
+			want: []StatusEntry{
+				{Index: 'A', Worktree: ' ', Path: "dot-zsh/dot-zshrc"},
+				{Index: ' ', Worktree: 'D', Path: "dot-vim/colors/solarized.vim"},
+			},
+			count: 2,
+		},
+		{
+			name: "rename records both paths",
+			out:  "R  dot-vim/old.vim -> dot-vim/new.vim\n",
+			want: []StatusEntry{
+				{Index: 'R', Worktree: ' ', Path: "dot-vim/new.vim", OrigPath: "dot-vim/old.vim"},
+			},
+			count: 1,
+		},
+		{
+			name: "quoted path is unquoted",
+			out:  "?? \"dot-vim/spaced name.vim\"\n",
+			want: []StatusEntry{
+				{Index: '?', Worktree: '?', Path: "dot-vim/spaced name.vim"},
+			},
+			count: 1,
+		},
+		{
+			name: "unmerged entry",
+			out:  "UU dot-vim/dot-vimrc\n",
+			want: []StatusEntry{
+				{Index: 'U', Worktree: 'U', Path: "dot-vim/dot-vimrc"},
+			},
+			count: 1,
+		},
+		{
+			name: "repository root file",
+			out:  " M README.md\n",
+			want: []StatusEntry{
+				{Index: ' ', Worktree: 'M', Path: "README.md"},
+			},
+			count: 1,
+		},
+		{
+			name:  "malformed short line is skipped",
+			out:   "M\n",
+			want:  []StatusEntry{},
+			count: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParsePorcelain(tt.out)
+			assert.Len(t, got, tt.count)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestStatusEntry_Code(t *testing.T) {
+	entry := StatusEntry{Index: '?', Worktree: '?', Path: "a"}
+	assert.Equal(t, "??", entry.Code())
+}
+
+func TestGroupByPackage(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []StatusEntry
+		want    []PackageGroup
+	}{
+		{
+			name:    "no entries",
+			entries: nil,
+			want:    []PackageGroup{},
+		},
+		{
+			name: "single package",
+			entries: []StatusEntry{
+				{Index: ' ', Worktree: 'M', Path: "dot-vim/dot-vimrc"},
+			},
+			want: []PackageGroup{
+				{
+					Package: "dot-vim",
+					Entries: []StatusEntry{{Index: ' ', Worktree: 'M', Path: "dot-vim/dot-vimrc"}},
+				},
+			},
+		},
+		{
+			name: "packages sorted, files sorted within package",
+			entries: []StatusEntry{
+				{Index: ' ', Worktree: 'M', Path: "dot-zsh/dot-zshrc"},
+				{Index: ' ', Worktree: 'M', Path: "dot-vim/z.vim"},
+				{Index: '?', Worktree: '?', Path: "dot-vim/a.vim"},
+			},
+			want: []PackageGroup{
+				{
+					Package: "dot-vim",
+					Entries: []StatusEntry{
+						{Index: '?', Worktree: '?', Path: "dot-vim/a.vim"},
+						{Index: ' ', Worktree: 'M', Path: "dot-vim/z.vim"},
+					},
+				},
+				{
+					Package: "dot-zsh",
+					Entries: []StatusEntry{{Index: ' ', Worktree: 'M', Path: "dot-zsh/dot-zshrc"}},
+				},
+			},
+		},
+		{
+			name: "root files grouped separately and listed first",
+			entries: []StatusEntry{
+				{Index: ' ', Worktree: 'M', Path: "dot-vim/dot-vimrc"},
+				{Index: ' ', Worktree: 'M', Path: "README.md"},
+			},
+			want: []PackageGroup{
+				{
+					Package: "",
+					Entries: []StatusEntry{{Index: ' ', Worktree: 'M', Path: "README.md"}},
+				},
+				{
+					Package: "dot-vim",
+					Entries: []StatusEntry{{Index: ' ', Worktree: 'M', Path: "dot-vim/dot-vimrc"}},
+				},
+			},
+		},
+		{
+			name: "untracked directory entry",
+			entries: []StatusEntry{
+				{Index: '?', Worktree: '?', Path: "dot-tmux/"},
+			},
+			want: []PackageGroup{
+				{
+					Package: "dot-tmux",
+					Entries: []StatusEntry{{Index: '?', Worktree: '?', Path: "dot-tmux/"}},
+				},
+			},
+		},
+		{
+			name: "rename groups by new path",
+			entries: []StatusEntry{
+				{Index: 'R', Worktree: ' ', Path: "dot-zsh/new", OrigPath: "dot-vim/old"},
+			},
+			want: []PackageGroup{
+				{
+					Package: "dot-zsh",
+					Entries: []StatusEntry{{Index: 'R', Worktree: ' ', Path: "dot-zsh/new", OrigPath: "dot-vim/old"}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GroupByPackage(tt.entries)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPackageGroup_Label(t *testing.T) {
+	assert.Equal(t, "dot-vim", PackageGroup{Package: "dot-vim"}.Label())
+	assert.Equal(t, RootLabel, PackageGroup{Package: ""}.Label())
+}
+
+func TestPackageLabels(t *testing.T) {
+	groups := []PackageGroup{{Package: ""}, {Package: "dot-vim"}}
+	assert.Equal(t, []string{RootLabel, "dot-vim"}, PackageLabels(groups))
+}
+
+func TestShortHostname(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{"fqdn", "zeus.int.example.com", "zeus"},
+		{"short name", "zeus", "zeus"},
+		{"empty", "", "unknown-host"},
+		{"leading dot", ".local", "unknown-host"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ShortHostname(tt.host))
+		})
+	}
+}
+
+func TestCommitMessage(t *testing.T) {
+	tests := []struct {
+		name   string
+		host   string
+		groups []PackageGroup
+		want   string
+	}{
+		{
+			name:   "single package",
+			host:   "zeus",
+			groups: []PackageGroup{{Package: "dot-vim"}},
+			want:   "sync: zeus local edits (dot-vim)",
+		},
+		{
+			name:   "multiple packages comma separated",
+			host:   "zeus.local",
+			groups: []PackageGroup{{Package: "dot-vim"}, {Package: "dot-zsh"}},
+			want:   "sync: zeus local edits (dot-vim, dot-zsh)",
+		},
+		{
+			name:   "root files use root label",
+			host:   "luggage",
+			groups: []PackageGroup{{Package: ""}},
+			want:   "sync: luggage local edits (" + RootLabel + ")",
+		},
+		{
+			name:   "no groups omits package list",
+			host:   "luggage",
+			groups: nil,
+			want:   "sync: luggage local edits",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, CommitMessage(tt.host, tt.groups))
+		})
+	}
+}
+
+func TestParsePorcelainThenGroup(t *testing.T) {
+	out := " M dot-vim/dot-vimrc\n?? dot-zsh/dot-zshrc\n M README.md\n"
+
+	groups := GroupByPackage(ParsePorcelain(out))
+	require.Len(t, groups, 3)
+
+	assert.Equal(t, RootLabel, groups[0].Label())
+	assert.Equal(t, "dot-vim", groups[1].Package)
+	assert.Equal(t, "dot-zsh", groups[2].Package)
+}

--- a/internal/gitsync/status_test.go
+++ b/internal/gitsync/status_test.go
@@ -205,9 +205,9 @@ func TestPackageGroup_Label(t *testing.T) {
 	assert.Equal(t, RootLabel, PackageGroup{Package: ""}.Label())
 }
 
-func TestPackageLabels(t *testing.T) {
+func TestCommitLabels(t *testing.T) {
 	groups := []PackageGroup{{Package: ""}, {Package: "dot-vim"}}
-	assert.Equal(t, []string{RootLabel, "dot-vim"}, PackageLabels(groups))
+	assert.Equal(t, []string{RootCommitToken, "dot-vim"}, commitLabels(groups))
 }
 
 func TestShortHostname(t *testing.T) {
@@ -249,10 +249,16 @@ func TestCommitMessage(t *testing.T) {
 			want:   "sync: zeus local edits (dot-vim, dot-zsh)",
 		},
 		{
-			name:   "root files use root label",
+			name:   "root files use a bare token, not the bracketed label",
 			host:   "luggage",
 			groups: []PackageGroup{{Package: ""}},
-			want:   "sync: luggage local edits (" + RootLabel + ")",
+			want:   "sync: luggage local edits (repo root)",
+		},
+		{
+			name:   "root files mix with packages",
+			host:   "luggage",
+			groups: []PackageGroup{{Package: ""}, {Package: "dot-vim"}},
+			want:   "sync: luggage local edits (repo root, dot-vim)",
 		},
 		{
 			name:   "no groups omits package list",


### PR DESCRIPTION
New dot sync subcommand: git pull --rebase --autostash in the package dir, remanage of manifest packages, status summary, and a dirty-file warning block grouped by package; dot sync --push commits and pushes local edits. Rebase conflicts stop with guidance and non-zero exit. Covers the unborn-HEAD and vanished-package edge cases. Docs: 05-commands.md and the multi-machine section of 06-workflows.md.