### PR TITLE
feat(nix): package the CLI as a flake; expand config paths; layout docs parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ go.work
 /dist/
 /build/
 
+# Nix build output symlinks
+/result
+/result-*
+
 # IDE
 .idea/
 .vscode/

--- a/README.md
+++ b/README.md
@@ -56,6 +56,26 @@ curl -L "https://github.com/yaklabco/dot/releases/download/v${VERSION}/dot_${VER
 sudo mv dot /usr/local/bin/
 ```
 
+### Nix
+
+The repository is a flake with `x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, and
+`aarch64-darwin` outputs:
+
+```bash
+# Run without installing
+nix run github:yaklabco/dot -- --help
+
+# Build into ./result
+nix build github:yaklabco/dot
+
+# Install into a profile
+nix profile install github:yaklabco/dot
+```
+
+To pull it into a system or home-manager configuration, add
+`dot.url = "github:yaklabco/dot"` to your flake inputs and use
+`dot.packages.${system}.default`.
+
 ### From Source
 
 Requires Go 1.26.1 or later:
@@ -128,10 +148,14 @@ dot manage dot-vim
 
 This creates `~/.vim/vimrc` pointing to `~/dotfiles/dot-vim/vimrc`.
 
-Package names determine target directories:
+Under the default name-mapped layout, package names determine target directories:
 - `dot-vim` → `~/.vim/`
 - `dot-gnupg` → `~/.gnupg/`
 - `vim` → `~/vim/`
+
+Set `dotfile.package_name_mapping: false` for the full-tree layout instead, where the
+package mirrors the target directory as in GNU Stow. See
+[Repository Layouts](#repository-layouts).
 
 ### Check Status
 
@@ -163,14 +187,28 @@ The destination directory where symlinks are created. Default: `$HOME`.
 
 A directory within the package directory containing configuration files.
 
-### Package Name Mapping
+### Repository Layouts
 
-Package names determine target directories (default behavior):
+dot supports two repository layouts, selected by `dotfile.package_name_mapping`.
+Both are fully supported; choose the one that fits how your repository is organised.
+
+**Name-mapped layout** (`package_name_mapping: true`, the default). The package name
+is the target directory it owns:
 - Package `dot-vim` → files installed to `~/.vim/`
 - Package `dot-gnupg` → files installed to `~/.gnupg/`
 - Package `config` → files installed to `~/config/`
 
-This eliminates redundant nesting and makes package naming intuitive.
+This removes a level of nesting from the repository, at the cost of not being able
+to place a file directly at `~/.vimrc`.
+
+**Full-tree layout** (`package_name_mapping: false`). The package name identifies the
+package only, and the tree inside it mirrors the target directory, the way GNU Stow
+works:
+- `vim/dot-vimrc` → `~/.vimrc`
+- `gnupg/dot-gnupg/gpg.conf` → `~/.gnupg/gpg.conf`
+
+Choose this when migrating an existing Stow repository, or when one package needs to
+place files in several different directories under the target.
 
 ### Dotfile Translation
 
@@ -499,11 +537,17 @@ Environment and flag overlays cover a subset of keys only; see
 
 ### Configuration Example
 
+Path values are expanded when the configuration is loaded: a leading `~` resolves to
+the home directory and `$VAR` or `${VAR}` resolves from the environment. This applies
+to `directories.package`, `directories.target`, `directories.manifest`,
+`symlinks.backup_dir`, and `logging.file`. Quote a bare tilde, because an unquoted
+`target: ~` is YAML null rather than a path.
+
 ```yaml
 # ~/.config/dot/config.yaml
 directories:
   package: ~/dotfiles
-  target: ~
+  target: "~"
 
 logging:
   level: INFO
@@ -562,7 +606,7 @@ for the complete 12-section schema.
 | `ignore.use_defaults` | boolean | `true` | Apply the built-in ignore pattern set |
 | `ignore.patterns` | array | `[]` | Additional patterns to exclude |
 | `dotfile.translate` | boolean | `true` | Translate `dot-` file prefixes to `.` |
-| `dotfile.package_name_mapping` | boolean | `true` | Map package name to a target subdirectory |
+| `dotfile.package_name_mapping` | boolean | `true` | `true` for the name-mapped layout, `false` for the full-tree (Stow-style) layout |
 | `output.format` | string | `text` | `text`, `json`, `yaml`, or `table` |
 | `operations.atomic` | boolean | `true` | Roll back the whole plan on any failure |
 

--- a/cmd/dot/config_upgrade_test.go
+++ b/cmd/dot/config_upgrade_test.go
@@ -17,6 +17,11 @@ func TestConfigUpgrade_WithOldConfig(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, "config.yaml")
 
+	// The golden tests in this package set and unset HOME with os.Setenv, so
+	// pin it here rather than inheriting whatever ran last: the "~" below is
+	// only resolvable with a home directory.
+	t.Setenv("HOME", t.TempDir())
+
 	// Create an old-style config with some custom values
 	oldConfig := `directories:
   package: "/custom/dotfiles"
@@ -59,7 +64,12 @@ ignore:
 
 	// Verify user values were preserved
 	assert.Equal(t, "/custom/dotfiles", upgraded.Directories.Package)
-	assert.Equal(t, "~", upgraded.Directories.Target)
+
+	// Path values are expanded on load, so the loaded target is this machine's
+	// home directory. The file keeps the portable "~", asserted below.
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	assert.Equal(t, home, upgraded.Directories.Target)
 	assert.Equal(t, "DEBUG", upgraded.Logging.Level)
 	assert.Equal(t, "json", upgraded.Logging.Format)
 	assert.Equal(t, "absolute", upgraded.Symlinks.Mode)
@@ -82,6 +92,7 @@ ignore:
 	content, err := os.ReadFile(configPath)
 	require.NoError(t, err)
 	contentStr := string(content)
+	assert.Contains(t, contentStr, `target: "~"`, "upgrade keeps the path as the user wrote it")
 	assert.Contains(t, contentStr, "# Dot Configuration")
 	assert.Contains(t, contentStr, "# Upgraded on")
 	assert.Contains(t, contentStr, "# Backup saved to:")

--- a/docs/user/04-configuration.md
+++ b/docs/user/04-configuration.md
@@ -183,13 +183,12 @@ Set a specific value:
 dot config set directories.package ~/dotfiles
 ```
 
-`dot config set` and `dot config upgrade` rewrite the whole file from the loaded configuration, and
-because paths are expanded on load, any `~` or `$VAR` you had written by hand is replaced by its
-resolved absolute path. Edit the file directly when you want to keep those references, which is
-usually what you want for a repository config that is shared across machines.
+`dot config set` and `dot config upgrade` rewrite the whole file, but they read it verbatim first,
+so a `~` or `$VAR` you wrote by hand is written back unchanged. A repository config shared across
+machines stays portable through both commands.
 
-`dot config list` and `dot config get` also report expanded values, which is the quickest way to
-confirm where a path actually resolves.
+`dot config list` and `dot config get` report expanded values, which is the quickest way to confirm
+where a path actually resolves.
 
 ## Configuration Options
 
@@ -214,8 +213,8 @@ as `ignore.patterns` and `dotfile.prefix` are matched verbatim, tilde and all.
 
 Three details are worth knowing:
 
-- A variable that is not set expands to the empty string, exactly as in a shell, so
-  `package: $UNSET_VAR/dotfiles` becomes `/dotfiles`.
+- A variable that is not set is an error naming the variable, unlike a shell, where
+  `package: $UNSET_VAR/dotfiles` would quietly become `/dotfiles`.
 - Only a leading `~` or `~/` is a home reference. `~alice/.dotfiles` is left alone, and so is a
   tilde anywhere but the start.
 - In YAML, an unquoted `target: ~` is null rather than a string; it leaves the key unset and the

--- a/docs/user/04-configuration.md
+++ b/docs/user/04-configuration.md
@@ -183,6 +183,14 @@ Set a specific value:
 dot config set directories.package ~/dotfiles
 ```
 
+`dot config set` and `dot config upgrade` rewrite the whole file from the loaded configuration, and
+because paths are expanded on load, any `~` or `$VAR` you had written by hand is replaced by its
+resolved absolute path. Edit the file directly when you want to keep those references, which is
+usually what you want for a repository config that is shared across machines.
+
+`dot config list` and `dot config get` also report expanded values, which is the quickest way to
+confirm where a path actually resolves.
+
 ## Configuration Options
 
 Configuration is organised into sections. Keys are given as `section.field`. There is no flat
@@ -197,11 +205,21 @@ and the default silently remains in effect. Confirm every edit with `dot config 
 | `directories.target` | string | the user's home directory |
 | `directories.manifest` | string | `<XDG_DATA_HOME>/dot/manifest`, usually `$HOME/.local/share/dot/manifest` |
 
-**Write path values in full; there is no expansion.** A leading `~` and a `$VAR` reference are
-stored literally and then resolved against the working directory, so `target: ~/dotfiles` creates a
-directory named `~` under the current directory rather than under your home directory. Use an
-absolute path such as `/home/alice/dotfiles`. Note that `target: ~` on its own is YAML null, not a
-path; it leaves the key unset and the default applies.
+**Path values are expanded when the configuration is loaded.** A leading `~` resolves to your home
+directory and `$VAR` or `${VAR}` references resolve from the environment, so `package: ~/.dotfiles`
+and `manifest: $XDG_DATA_HOME/dot/manifest` both work and stay portable across machines. Expansion
+applies to path-typed values only: `directories.package`, `directories.target`,
+`directories.manifest`, `symlinks.backup_dir`, and `logging.file`. Pattern and prefix values such
+as `ignore.patterns` and `dotfile.prefix` are matched verbatim, tilde and all.
+
+Three details are worth knowing:
+
+- A variable that is not set expands to the empty string, exactly as in a shell, so
+  `package: $UNSET_VAR/dotfiles` becomes `/dotfiles`.
+- Only a leading `~` or `~/` is a home reference. `~alice/.dotfiles` is left alone, and so is a
+  tilde anywhere but the start.
+- In YAML, an unquoted `target: ~` is null rather than a string; it leaves the key unset and the
+  default applies. Write `target: "~"` when you mean the home directory.
 
 Relative paths in `directories.package` are resolved from the working directory. The manifest is a
 single JSON file, `.dot-manifest.json`, inside `directories.manifest`; by default that is
@@ -364,21 +382,41 @@ negation, and size filtering.
 With `dotfile.translate` enabled, a leading `dot-` in a source name becomes a leading `.` in the
 target name.
 
-With `dotfile.package_name_mapping` enabled, package names determine target directories:
+`dotfile.package_name_mapping` selects between the two supported repository layouts. Both are
+fully supported; pick the one that matches how your repository is organised.
+
+**Name-mapped layout** (`package_name_mapping: true`, the default). The package name determines the
+target directory:
 
 - Package `dot-vim` installs into `~/.vim/`
 - Package `dot-gnupg` installs into `~/.gnupg/`
 - Package `config` installs into `~/config/`
 
-This eliminates redundant directory nesting: `dot-gnupg/gpg.conf` links to `~/.gnupg/gpg.conf`
-rather than `~/gpg.conf`. Set it to `false` to restore the legacy behaviour, in which the package
-name is used only for identification and the package structure must mirror the target structure.
+This removes a level of nesting inside the repository: `dot-gnupg/gpg.conf` links to
+`~/.gnupg/gpg.conf`, and the package directory holds only the files themselves.
 
 ```yaml
 dotfile:
   translate: true
   prefix: "dot-"
   package_name_mapping: true
+```
+
+**Full-tree layout** (`package_name_mapping: false`). The package name identifies the package only,
+and the directory tree inside the package mirrors the target directory, which is how GNU Stow
+works:
+
+- `gnupg/dot-gnupg/gpg.conf` links to `~/.gnupg/gpg.conf`
+- `vim/dot-vimrc` links to `~/.vimrc`
+
+Choose this layout when you are migrating an existing Stow repository or when a single package
+needs to place files in several different directories under the target.
+
+```yaml
+dotfile:
+  translate: true
+  prefix: "dot-"
+  package_name_mapping: false
 ```
 
 ### output
@@ -516,20 +554,20 @@ export DOT_LOGGING_FORMAT=json
 
 `~/.config/dot/config.yaml`:
 
-Paths are written in full because no expansion is performed. Substitute your own home directory
-for `/home/alice`.
+Paths are written home-relative so the same file works on every machine; absolute paths are equally
+valid where a location really is machine-specific.
 
 ```yaml
 directories:
-  package: /home/alice/dotfiles
-  target: /home/alice
-  manifest: /home/alice/.local/share/dot/manifest
+  package: ~/dotfiles
+  target: "~"
+  manifest: ~/.local/share/dot/manifest
 
 logging:
   level: INFO
   format: text
   destination: stderr
-  file: /home/alice/.local/state/dot/dot.log
+  file: ~/.local/state/dot/dot.log
 
 symlinks:
   mode: relative
@@ -537,7 +575,7 @@ symlinks:
   overwrite: false
   backup: true
   backup_suffix: ".bak"
-  backup_dir: /home/alice/.dot-backups
+  backup_dir: ~/.dot-backups
 
 ignore:
   use_defaults: true
@@ -772,9 +810,11 @@ directories:
   package: /home/alice/dotfiles
 ```
 
-### 3. Use Absolute Paths
+### 3. Prefer Home-Relative Paths
 
-Path values are not expanded. Write `/home/alice/dotfiles`, never `~/dotfiles` or `$HOME/dotfiles`.
+Path values are expanded on load, so `~/dotfiles` and `$HOME/dotfiles` both resolve correctly and
+keep the file portable across machines and user accounts. Reach for an absolute path such as
+`/home/alice/dotfiles` only when the location genuinely is machine-specific.
 
 ### 4. Document Custom Settings
 
@@ -784,7 +824,7 @@ Add comments explaining non-obvious choices:
 symlinks:
   # Back up rather than fail, because this host has pre-existing configs
   backup: true
-  backup_dir: /home/alice/.dot-backups
+  backup_dir: ~/.dot-backups
 ```
 
 ### 5. Verify After Editing

--- a/docs/user/migration-from-stow.md
+++ b/docs/user/migration-from-stow.md
@@ -33,22 +33,34 @@ brew install dot
 
 ### Step 2: Understand the Layout Difference
 
-By default dot maps the package name to a target subdirectory, controlled by the
-`dotfile.package_name_mapping` key, which is enabled by default. Package `vim`
-targets `~/vim/`, not `~/`. A Stow package carried across unchanged will
-therefore link into the wrong location.
+dot supports two repository layouts, selected by `dotfile.package_name_mapping`.
+Neither is deprecated; they suit different repositories, and a Stow user is
+choosing between them rather than migrating away from one.
 
-Choose one of the following before migrating:
+**Full-tree layout** (`dotfile.package_name_mapping: false`). The package name
+identifies the package only, and the tree inside the package mirrors the target
+directory, exactly as Stow works. `vim/dot-vimrc` becomes `~/.vimrc`. Set this in
+`~/.config/dot/config.yaml`, or better in the repository config so every machine
+picks it up:
 
-1. Keep Stow semantics by setting `dotfile.package_name_mapping: false` in
-   `~/.config/dot/config.yaml`. Package contents are then placed directly under
-   the target directory, as Stow does. This is the closest equivalent and the
-   only option that reproduces top-level dotfiles such as `~/.vimrc` from a
-   package named `vim`.
-2. Restructure each package so that its name is the directory it owns. A package
-   named `dot-ssh` targets `~/.ssh/`, so `dot-ssh/config` becomes `~/.ssh/config`.
-   This suits packages that own a single dotted directory, but it cannot place a
-   file directly at `~/.vimrc`, because every package maps to a subdirectory.
+```yaml
+dotfile:
+  package_name_mapping: false
+```
+
+This is the closest equivalent to Stow and the layout to choose when a single
+package owns files in several places, or owns a top-level dotfile such as
+`~/.vimrc`.
+
+**Name-mapped layout** (`dotfile.package_name_mapping: true`, the default). The
+package name is the directory it owns: `dot-ssh` targets `~/.ssh/`, so
+`dot-ssh/config` becomes `~/.ssh/config` with no intermediate directory in the
+repository. This suits repositories where each package owns one dotted
+directory. It cannot place a file directly at `~/.vimrc`, because every package
+maps to a subdirectory.
+
+Whichever you pick, a Stow package carried across unchanged under the default
+layout links into `~/vim/` rather than `~/`, so decide before migrating.
 
 ### Step 3: Test with One Package
 
@@ -110,7 +122,9 @@ Note that directory folding, which Stow performs, is not implemented in dot.
 ### Behavioral Differences
 
 1. **Dotfile Translation**: dot uses `dot-` prefix, Stow uses `.` in package
-2. **Package Name Mapping**: the package name selects the target subdirectory
+2. **Repository Layout**: under the default name-mapped layout the package name
+   selects the target subdirectory; `dotfile.package_name_mapping: false`
+   switches to the full-tree layout Stow users already have
 3. **Manifest**: dot maintains `.dot-manifest.json` under
    `~/.local/share/dot/manifest/` for state tracking
 4. **Conflict Resolution**: dot fails on conflict by default; the
@@ -132,11 +146,15 @@ the `DOT_CONFIG` environment variable. Generate a commented default with
 ```yaml
 directories:
   package: ~/dotfiles    # stow -d
-  target: ~              # stow -t
+  target: "~"            # stow -t
 
 symlinks:
   mode: relative         # Stow's default link style
 ```
+
+A leading `~` and `$VAR` references in path values are expanded when the config
+is loaded, so these are portable across machines. Quote a bare tilde: unquoted,
+`target: ~` is YAML null and the key is left unset.
 
 ## Package Structure
 
@@ -150,19 +168,33 @@ dotfiles/
         └── colors/
 ```
 
-### dot (Recommended)
+### dot, full-tree layout
+
+`dotfile.package_name_mapping: false`. The package mirrors the target tree, as
+in Stow:
 
 ```
 dotfiles/
 └── vim/
-    ├── dot-vimrc        # Translates to .vimrc
-    └── dot-vim/         # Translates to .vim/
+    ├── dot-vimrc        # Translates to ~/.vimrc
+    └── dot-vim/         # Translates to ~/.vim/
         └── colors/
 ```
 
-Note: dot reads files whose names already begin with `.`, but the package name
-still determines the target subdirectory unless `dotfile.package_name_mapping`
-is disabled.
+### dot, name-mapped layout
+
+`dotfile.package_name_mapping: true` (the default). The package name is the
+directory it owns, so the repository carries one level less nesting:
+
+```
+dotfiles/
+└── dot-vim/             # The package targets ~/.vim/
+    └── colors/
+```
+
+Note: dot reads files whose names already begin with `.`, so a Stow repository
+needs no renaming to be readable. The `dot-` prefix is a convention that keeps
+dotfiles visible in the repository, not a requirement.
 
 ## Common Migration Issues
 

--- a/docs/user/repository-config.md
+++ b/docs/user/repository-config.md
@@ -30,27 +30,36 @@ mkdir -p ~/.dotfiles/.config/dot
 $EDITOR ~/.dotfiles/.config/dot/config.yaml
 ```
 
-Example configuration. Path values are not expanded, so write them in full and substitute your own
-home directory for `/home/alice`:
+Example configuration. Path values are expanded when the config is loaded, so write them relative
+to the home directory and the same file works on every machine:
 
 ```yaml
 directories:
-  package: /home/alice/.dotfiles
-  target: /home/alice
-  manifest: /home/alice/.local/share/dot/manifest
+  package: ~/.dotfiles
+  target: "~"
+  manifest: ~/.local/share/dot/manifest
 
 symlinks:
   backup: true
-  backup_dir: /home/alice/.dotfiles.backup
+  backup_dir: ~/.dotfiles.backup
 
 dotfile:
   translate: true
   package_name_mapping: true
 ```
 
-A leading `~` or a `$VAR` reference is stored literally and resolved against the working directory,
-which produces a directory named `~` or `$HOME` rather than the intended location. This makes a
-committed repository config machine-specific: see Machine-Specific Settings below.
+A leading `~` resolves to the home directory of whoever runs `dot`, and `$VAR` or `${VAR}`
+references resolve from the environment. Expansion covers path-typed values only:
+`directories.package`, `directories.target`, `directories.manifest`, `symlinks.backup_dir`, and
+`logging.file`. Two details matter when writing YAML by hand:
+
+- Quote a bare tilde. Unquoted, `target: ~` is YAML null, which leaves the key unset so the default
+  applies; `target: "~"` is the string that expands to the home directory.
+- An unset variable expands to the empty string, so `package: $DOTFILES_ROOT/repo` becomes `/repo`
+  on a machine where `DOTFILES_ROOT` is not exported.
+
+Because of expansion, a committed repository config can pin `directories.package` and
+`directories.target` without hard-coding one machine's layout.
 
 ### 2. Commit and Share
 
@@ -95,7 +104,9 @@ The config file lives in the repository root at `.config/dot/config.yaml`. It is
 
 Your repository defines how it should be managed:
 
-- Package name mapping and dotfile translation
+- Which layout the repository uses: name-mapped (`dot-gnupg` to `~/.gnupg`) or full-tree, where the
+  package mirrors the target directory
+- Dotfile translation and its prefix
 - Ignore patterns
 - Backup behaviour
 - Output and logging preferences
@@ -108,21 +119,21 @@ The two files are not layered. If the repository config exists it is loaded in f
 `~/.config/dot/config.yaml` is not read at all, so a partial machine-local override is not possible
 while a repository config is present.
 
-This matters for paths in particular. Because `directories.package` and `directories.target` must
-be absolute and are not expanded, a committed repository config pins them to one machine's layout.
-Either omit those two keys from the repository config and supply them per machine, or accept that
-every machine must use the same paths.
+Paths are the easy part: because `~` and `$VAR` are expanded on load, `package: ~/.dotfiles` and
+`target: "~"` in a committed repository config resolve per machine and per user without any
+override. Reach for an environment variable when the layout itself differs, for example
+`package: $DOTFILES_ROOT` with `DOTFILES_ROOT` exported from each machine's shell profile.
 
-For per-machine differences, use command-line flags or the bound `DOT_*` environment variables,
-both of which take precedence over either file:
+Genuinely divergent settings still need flags or the bound `DOT_*` environment variables, both of
+which take precedence over either file:
 
 ```bash
 export DOT_DIRECTORIES_TARGET=/custom/path
 dot --dir ~/.dotfiles --target ~ manage vim
 ```
 
-Shell expansion applies on the command line, so `~` works there even though it does not work inside
-the configuration file.
+Values supplied that way are expanded too, so `DOT_DIRECTORIES_TARGET=~/staging` works whether or
+not the shell got to it first.
 
 ## Configuration Precedence
 
@@ -142,21 +153,41 @@ read.
 ```yaml
 # .config/dot/config.yaml in your repository
 directories:
-  package: /home/alice/.dotfiles
-  target: /home/alice
+  package: ~/.dotfiles
+  target: "~"
 
 dotfile:
   package_name_mapping: true
 ```
+
+### Full-Tree (Stow-Style) Repository Config
+
+Declare the layout your repository actually uses. A repository whose packages mirror the target
+tree sets `package_name_mapping: false`:
+
+```yaml
+# .config/dot/config.yaml in your repository
+directories:
+  package: ~/.dotfiles
+  target: "~"
+
+dotfile:
+  translate: true
+  prefix: "dot-"
+  package_name_mapping: false
+```
+
+Committing this key is the point of a repository config: whoever clones the repository gets the
+layout it was written for, with no per-machine flag.
 
 ### Advanced Configuration
 
 ```yaml
 # .config/dot/config.yaml
 directories:
-  package: /home/alice/my-dotfiles
-  target: /home/alice
-  manifest: /home/alice/.local/share/dot/manifest
+  package: ~/my-dotfiles
+  target: "~"
+  manifest: ~/.local/share/dot/manifest
 
 logging:
   level: INFO
@@ -165,7 +196,7 @@ logging:
 symlinks:
   mode: relative
   folding: true
-  backup_dir: /home/alice/.dotfiles.backup
+  backup_dir: ~/.dotfiles.backup
 
 ignore:
   use_defaults: true
@@ -221,7 +252,7 @@ If you use a different package directory (not `~/.dotfiles`), update the path:
 ```yaml
 # In your repository's .config/dot/config.yaml
 directories:
-  package: /home/alice/my-dotfiles  # Absolute, must match actual location
+  package: ~/my-dotfiles  # Must match the actual location after expansion
 ```
 
 Or use the `--dir` flag (short form `-d`):
@@ -283,10 +314,10 @@ git commit -m "feat(config): add dot configuration"
 
 Put configuration that should be the same across all machines in the repository:
 
-- Package directory location
+- Package directory location, written home-relative so it expands per machine
 - Target directory structure
 - Ignore patterns
-- Package name mapping preferences
+- The repository layout (`dotfile.package_name_mapping`)
 
 ### 2. Use Flags or Environment Variables for Machine-Specific Settings
 

--- a/docs/user/repository-config.md
+++ b/docs/user/repository-config.md
@@ -55,8 +55,9 @@ references resolve from the environment. Expansion covers path-typed values only
 
 - Quote a bare tilde. Unquoted, `target: ~` is YAML null, which leaves the key unset so the default
   applies; `target: "~"` is the string that expands to the home directory.
-- An unset variable expands to the empty string, so `package: $DOTFILES_ROOT/repo` becomes `/repo`
-  on a machine where `DOTFILES_ROOT` is not exported.
+- A variable that is not set is an error, not an empty string. On a machine where `DOTFILES_ROOT`
+  is not exported, `package: $DOTFILES_ROOT/repo` fails with a message naming the variable rather
+  than quietly resolving to `/repo`.
 
 Because of expansion, a committed repository config can pin `directories.package` and
 `directories.target` without hard-coding one machine's layout.
@@ -132,8 +133,10 @@ export DOT_DIRECTORIES_TARGET=/custom/path
 dot --dir ~/.dotfiles --target ~ manage vim
 ```
 
-Values supplied that way are expanded too, so `DOT_DIRECTORIES_TARGET=~/staging` works whether or
-not the shell got to it first.
+Environment values are expanded the same way the file is, so `DOT_DIRECTORIES_TARGET=~/staging`
+works whether or not the shell got to it first. Flag values are not: `--target ~/staging` works
+only because the shell expands the tilde before dot sees it, so never quote a tilde on the command
+line, and pass an absolute path from scripts.
 
 ## Configuration Precedence
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785090369,
+        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "624af665418d3c65d544145b4d34ad696439570e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,102 @@
+{
+  description = "dot: a safe, deterministic dotfile symlink manager";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      # Kept in step with the released tag. release-please bumps the tag; bump
+      # this alongside it so `dot --version` reports the same string the
+      # release binaries do.
+      version = "0.7.0";
+
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+
+      pkgsFor = system: nixpkgs.legacyPackages.${system};
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+
+          dot = pkgs.buildGoModule {
+            pname = "dot";
+            inherit version;
+
+            src = self;
+
+            vendorHash = "sha256-IHnitXddgagFpk0dK85hbZyqdIlXkndjgB7r/a1X5iY=";
+
+            subPackages = [ "cmd/dot" ];
+
+            ldflags = [
+              "-s"
+              "-w"
+              "-X main.version=${version}"
+              "-X main.commit=${self.shortRev or self.dirtyShortRev or "nix"}"
+              # A fixed timestamp keeps the build reproducible; the real build
+              # date is carried by the release artifacts, not by the Nix build.
+              "-X main.date=1970-01-01T00:00:00Z"
+            ];
+
+            # The suite drives the real filesystem and expects a writable HOME
+            # plus network access for a few integration paths, neither of which
+            # the Nix sandbox provides. Tests run in CI (make check) instead.
+            doCheck = false;
+
+            meta = {
+              description = "Safe, deterministic dotfile symlink manager";
+              homepage = "https://github.com/yaklabco/dot";
+              license = pkgs.lib.licenses.mit;
+              mainProgram = "dot";
+              platforms = systems;
+            };
+          };
+        in
+        {
+          inherit dot;
+          default = dot;
+        }
+      );
+
+      apps = forAllSystems (system: rec {
+        dot = {
+          type = "app";
+          program = "${self.packages.${system}.dot}/bin/dot";
+          meta.description = "Run the dot dotfile symlink manager";
+        };
+        default = dot;
+      });
+
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+        in
+        {
+          default = pkgs.mkShell {
+            packages = [
+              pkgs.go
+              pkgs.gopls
+              pkgs.golangci-lint
+              pkgs.gnumake
+              pkgs.git
+            ];
+          };
+        }
+      );
+
+      formatter = forAllSystems (system: (pkgsFor system).nixfmt-tree);
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -8,10 +8,11 @@
   outputs =
     { self, nixpkgs }:
     let
-      # Kept in step with the released tag. release-please bumps the tag; bump
-      # this alongside it so `dot --version` reports the same string the
-      # release binaries do.
-      version = "0.7.0";
+      # Read from the release-please manifest, which is the file release-please
+      # updates on every release, so the flake cannot drift from the released
+      # tag. It is the derivation version and the string compiled into
+      # main.version.
+      version = (builtins.fromJSON (builtins.readFile ./.release-please-manifest.json)).".";
 
       systems = [
         "x86_64-linux"

--- a/internal/config/expand.go
+++ b/internal/config/expand.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,9 +12,11 @@ import (
 //
 // Two substitutions are applied, in this order:
 //
-//  1. Environment variables, using os.ExpandEnv, so "$HOME/.dotfiles" and
-//     "${XDG_DATA_HOME}/dot" resolve. A variable that is not set expands to
-//     the empty string, matching shell behaviour.
+//  1. Environment variables, so "$HOME/.dotfiles" and "${XDG_DATA_HOME}/dot"
+//     resolve. Unlike a shell, a reference to a variable that is not set is
+//     an error rather than an empty string: silently turning
+//     "$DOTFILES_ROOT/repo" into the root-anchored "/repo" is never what the
+//     author meant.
 //  2. A leading tilde, so "~" becomes the current user's home directory and
 //     "~/.dotfiles" becomes "<home>/.dotfiles".
 //
@@ -23,25 +26,86 @@ import (
 // dotfile.prefix are left verbatim, because a tilde or dollar sign there is
 // part of the pattern rather than a path reference.
 //
-// The operation is idempotent: expanding an already expanded configuration
-// leaves it unchanged.
-func (c *ExtendedConfig) ExpandPaths() {
-	c.Directories.Package = expandPath(c.Directories.Package)
-	c.Directories.Target = expandPath(c.Directories.Target)
-	c.Directories.Manifest = expandPath(c.Directories.Manifest)
-	c.Symlinks.BackupDir = expandPath(c.Symlinks.BackupDir)
-	c.Logging.File = expandPath(c.Logging.File)
+// Expansion is applied once per configuration source: file values are
+// expanded as the file is loaded, and environment or flag overlays are
+// expanded before they are merged. Running it again over already expanded
+// values would re-interpret a "$" or a leading "~" that a resolved path
+// legitimately contains.
+//
+// On error the configuration is left as written, and the message names both
+// the offending key and the reference that could not be resolved.
+func (c *ExtendedConfig) ExpandPaths() error {
+	fields := []struct {
+		key   string
+		value *string
+	}{
+		{"directories.package", &c.Directories.Package},
+		{"directories.target", &c.Directories.Target},
+		{"directories.manifest", &c.Directories.Manifest},
+		{"symlinks.backup_dir", &c.Symlinks.BackupDir},
+		{"logging.file", &c.Logging.File},
+	}
+
+	expanded := make([]string, len(fields))
+	for i, field := range fields {
+		value, err := expandPath(*field.value)
+		if err != nil {
+			return fmt.Errorf("%s: %w", field.key, err)
+		}
+		expanded[i] = value
+	}
+
+	for i, field := range fields {
+		*field.value = expanded[i]
+	}
+
+	return nil
 }
 
 // expandPath expands environment variables and a leading tilde in a single
 // path value. An empty value stays empty, so callers can distinguish "unset"
 // from "set to the home directory".
-func expandPath(path string) string {
+func expandPath(path string) (string, error) {
 	if path == "" {
-		return ""
+		return "", nil
 	}
 
-	return expandTilde(os.ExpandEnv(path))
+	expanded, err := expandVariables(path)
+	if err != nil {
+		return "", err
+	}
+
+	return expandTilde(expanded)
+}
+
+// expandVariables replaces "$VAR" and "${VAR}" with their environment values.
+// A reference to a variable that is not set is reported rather than expanded
+// to the empty string, because an empty expansion yields a path that looks
+// plausible ("/repo") while pointing somewhere the author never named.
+func expandVariables(path string) (string, error) {
+	var missing []string
+
+	expanded := os.Expand(path, func(name string) string {
+		value, found := os.LookupEnv(name)
+		if !found {
+			if !contains(missing, name) {
+				missing = append(missing, name)
+			}
+			return ""
+		}
+		return value
+	})
+
+	if len(missing) > 0 {
+		names := make([]string, 0, len(missing))
+		for _, name := range missing {
+			names = append(names, "$"+name)
+		}
+		return "", fmt.Errorf("undefined environment variable %s in %q",
+			strings.Join(names, ", "), path)
+	}
+
+	return expanded, nil
 }
 
 // expandTilde replaces a leading "~" or "~/" with the current user's home
@@ -49,22 +113,25 @@ func expandPath(path string) string {
 // start, are returned unchanged: dot does not resolve other users' home
 // directories, and a tilde inside a path is a legitimate directory name.
 //
-// When the home directory cannot be determined the value is returned as
-// written, leaving the caller to fail on the literal path rather than
-// silently relocating it.
-func expandTilde(path string) string {
+// A home directory that cannot be determined is an error, so the caller sees
+// which key could not be resolved rather than a later failure on a literal
+// path named "~".
+func expandTilde(path string) (string, error) {
 	if path != "~" && !strings.HasPrefix(path, "~/") {
-		return path
+		return path, nil
 	}
 
 	home, err := os.UserHomeDir()
-	if err != nil || home == "" {
-		return path
+	if err != nil {
+		return "", fmt.Errorf("resolve %q: %w", path, err)
+	}
+	if home == "" {
+		return "", fmt.Errorf("resolve %q: home directory is empty", path)
 	}
 
 	if path == "~" {
-		return home
+		return home, nil
 	}
 
-	return filepath.Join(home, path[len("~/"):])
+	return filepath.Join(home, path[len("~/"):]), nil
 }

--- a/internal/config/expand.go
+++ b/internal/config/expand.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ExpandPaths resolves shell-style references in every path-typed
+// configuration value, in place.
+//
+// Two substitutions are applied, in this order:
+//
+//  1. Environment variables, using os.ExpandEnv, so "$HOME/.dotfiles" and
+//     "${XDG_DATA_HOME}/dot" resolve. A variable that is not set expands to
+//     the empty string, matching shell behaviour.
+//  2. A leading tilde, so "~" becomes the current user's home directory and
+//     "~/.dotfiles" becomes "<home>/.dotfiles".
+//
+// Only path-typed values are touched: directories.package,
+// directories.target, directories.manifest, symlinks.backup_dir, and
+// logging.file. Pattern and prefix values such as ignore.patterns and
+// dotfile.prefix are left verbatim, because a tilde or dollar sign there is
+// part of the pattern rather than a path reference.
+//
+// The operation is idempotent: expanding an already expanded configuration
+// leaves it unchanged.
+func (c *ExtendedConfig) ExpandPaths() {
+	c.Directories.Package = expandPath(c.Directories.Package)
+	c.Directories.Target = expandPath(c.Directories.Target)
+	c.Directories.Manifest = expandPath(c.Directories.Manifest)
+	c.Symlinks.BackupDir = expandPath(c.Symlinks.BackupDir)
+	c.Logging.File = expandPath(c.Logging.File)
+}
+
+// expandPath expands environment variables and a leading tilde in a single
+// path value. An empty value stays empty, so callers can distinguish "unset"
+// from "set to the home directory".
+func expandPath(path string) string {
+	if path == "" {
+		return ""
+	}
+
+	return expandTilde(os.ExpandEnv(path))
+}
+
+// expandTilde replaces a leading "~" or "~/" with the current user's home
+// directory. Other forms, including "~user" and a tilde anywhere but the
+// start, are returned unchanged: dot does not resolve other users' home
+// directories, and a tilde inside a path is a legitimate directory name.
+//
+// When the home directory cannot be determined the value is returned as
+// written, leaving the caller to fail on the literal path rather than
+// silently relocating it.
+func expandTilde(path string) string {
+	if path != "~" && !strings.HasPrefix(path, "~/") {
+		return path
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return path
+	}
+
+	if path == "~" {
+		return home
+	}
+
+	return filepath.Join(home, path[len("~/"):])
+}

--- a/internal/config/expand_test.go
+++ b/internal/config/expand_test.go
@@ -1,0 +1,335 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklabco/dot/internal/config"
+)
+
+func TestExtendedConfig_ExpandPaths(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("DOT_TEST_ROOT", "/srv/dotfiles")
+	t.Setenv("DOT_TEST_TILDE", "~/outer")
+
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{
+			name:  "bare tilde becomes home",
+			value: "~",
+			want:  home,
+		},
+		{
+			name:  "leading tilde is joined with home",
+			value: "~/.dotfiles",
+			want:  filepath.Join(home, ".dotfiles"),
+		},
+		{
+			name:  "nested tilde path is joined with home",
+			value: "~/.local/share/dot/manifest",
+			want:  filepath.Join(home, ".local/share/dot/manifest"),
+		},
+		{
+			name:  "bare environment variable is expanded",
+			value: "$DOT_TEST_ROOT",
+			want:  "/srv/dotfiles",
+		},
+		{
+			name:  "environment variable with suffix is expanded",
+			value: "$DOT_TEST_ROOT/packages",
+			want:  "/srv/dotfiles/packages",
+		},
+		{
+			name:  "braced environment variable is expanded",
+			value: "${DOT_TEST_ROOT}/packages",
+			want:  "/srv/dotfiles/packages",
+		},
+		{
+			name:  "HOME variable is expanded",
+			value: "$HOME/.dotfiles",
+			want:  filepath.Join(home, ".dotfiles"),
+		},
+		{
+			name:  "environment variable expanding to a tilde path is expanded twice",
+			value: "$DOT_TEST_TILDE/inner",
+			want:  filepath.Join(home, "outer/inner"),
+		},
+		{
+			name:  "undefined variable expands to empty",
+			value: "$DOT_TEST_UNDEFINED/packages",
+			want:  "/packages",
+		},
+		{
+			name:  "absolute path is unchanged",
+			value: "/etc/dot",
+			want:  "/etc/dot",
+		},
+		{
+			name:  "relative path is unchanged",
+			value: ".",
+			want:  ".",
+		},
+		{
+			name:  "empty value stays empty",
+			value: "",
+			want:  "",
+		},
+		{
+			name:  "tilde in the middle is not a home reference",
+			value: "/opt/~/cache",
+			want:  "/opt/~/cache",
+		},
+		{
+			name:  "named tilde is left alone",
+			value: "~alice/.dotfiles",
+			want:  "~alice/.dotfiles",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.DefaultExtended()
+			cfg.Directories.Package = tt.value
+			cfg.Directories.Target = tt.value
+			cfg.Directories.Manifest = tt.value
+			cfg.Symlinks.BackupDir = tt.value
+			cfg.Logging.File = tt.value
+
+			cfg.ExpandPaths()
+
+			assert.Equal(t, tt.want, cfg.Directories.Package, "directories.package")
+			assert.Equal(t, tt.want, cfg.Directories.Target, "directories.target")
+			assert.Equal(t, tt.want, cfg.Directories.Manifest, "directories.manifest")
+			assert.Equal(t, tt.want, cfg.Symlinks.BackupDir, "symlinks.backup_dir")
+			assert.Equal(t, tt.want, cfg.Logging.File, "logging.file")
+		})
+	}
+}
+
+func TestExtendedConfig_ExpandPathsLeavesNonPathValues(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	cfg := config.DefaultExtended()
+	cfg.Dotfile.Prefix = "~dot-"
+	cfg.Symlinks.BackupSuffix = "$HOME.bak"
+	cfg.Ignore.Patterns = []string{"~/*.local", "$HOME/secret"}
+	cfg.Update.Repository = "yaklabco/dot"
+
+	cfg.ExpandPaths()
+
+	assert.Equal(t, "~dot-", cfg.Dotfile.Prefix)
+	assert.Equal(t, "$HOME.bak", cfg.Symlinks.BackupSuffix)
+	assert.Equal(t, []string{"~/*.local", "$HOME/secret"}, cfg.Ignore.Patterns)
+	assert.Equal(t, "yaklabco/dot", cfg.Update.Repository)
+}
+
+func TestExtendedConfig_ExpandPathsIsIdempotent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := config.DefaultExtended()
+	cfg.Directories.Target = "~"
+	cfg.Directories.Package = "~/.dotfiles"
+
+	cfg.ExpandPaths()
+	first := *cfg
+	cfg.ExpandPaths()
+
+	assert.Equal(t, first.Directories.Target, cfg.Directories.Target)
+	assert.Equal(t, first.Directories.Package, cfg.Directories.Package)
+}
+
+func TestLoadExtendedFromFile_ExpandsPathValues(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("DOT_TEST_ROOT", "/srv/dotfiles")
+
+	tests := []struct {
+		name         string
+		content      string
+		wantPackage  string
+		wantTarget   string
+		wantManifest string
+		wantBackup   string
+		wantLogFile  string
+	}{
+		{
+			name: "tilde paths are expanded to home",
+			content: `
+directories:
+  package: ~/.dotfiles
+  target: "~"
+  manifest: ~/.local/share/dot/manifest
+symlinks:
+  backup_dir: ~/.dotfiles.backup
+logging:
+  file: ~/.local/state/dot/dot.log
+`,
+			wantPackage:  filepath.Join(home, ".dotfiles"),
+			wantTarget:   home,
+			wantManifest: filepath.Join(home, ".local/share/dot/manifest"),
+			wantBackup:   filepath.Join(home, ".dotfiles.backup"),
+			wantLogFile:  filepath.Join(home, ".local/state/dot/dot.log"),
+		},
+		{
+			name: "environment variables are expanded",
+			content: `
+directories:
+  package: $DOT_TEST_ROOT/packages
+  target: $HOME
+  manifest: ${DOT_TEST_ROOT}/manifest
+symlinks:
+  backup_dir: $DOT_TEST_ROOT/backup
+logging:
+  file: $DOT_TEST_ROOT/dot.log
+`,
+			wantPackage:  "/srv/dotfiles/packages",
+			wantTarget:   home,
+			wantManifest: "/srv/dotfiles/manifest",
+			wantBackup:   "/srv/dotfiles/backup",
+			wantLogFile:  "/srv/dotfiles/dot.log",
+		},
+		{
+			name: "absolute paths are preserved verbatim",
+			content: `
+directories:
+  package: /test/dotfiles
+  target: /test/home
+  manifest: /test/manifest
+symlinks:
+  backup_dir: /test/backup
+logging:
+  file: /test/dot.log
+`,
+			wantPackage:  "/test/dotfiles",
+			wantTarget:   "/test/home",
+			wantManifest: "/test/manifest",
+			wantBackup:   "/test/backup",
+			wantLogFile:  "/test/dot.log",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "config.yaml")
+			require.NoError(t, os.WriteFile(configPath, []byte(tt.content), 0o600))
+
+			cfg, err := config.LoadExtendedFromFile(configPath)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantPackage, cfg.Directories.Package)
+			assert.Equal(t, tt.wantTarget, cfg.Directories.Target)
+			assert.Equal(t, tt.wantManifest, cfg.Directories.Manifest)
+			assert.Equal(t, tt.wantBackup, cfg.Symlinks.BackupDir)
+			assert.Equal(t, tt.wantLogFile, cfg.Logging.File)
+		})
+	}
+}
+
+// TestLoadExtendedFromFile_PortableRepositoryConfig covers the use case from
+// issue #80: a repository config committed to a dotfiles repository can now
+// name paths relative to the home directory and stay portable across machines.
+func TestLoadExtendedFromFile_PortableRepositoryConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoConfigDir := filepath.Join(home, ".dotfiles", ".config", "dot")
+	require.NoError(t, os.MkdirAll(repoConfigDir, 0o755))
+
+	configPath := filepath.Join(repoConfigDir, "config.yaml")
+	content := `
+directories:
+  package: ~/.dotfiles
+  target: "~"
+  manifest: ~/.local/share/dot/manifest
+
+symlinks:
+  backup: true
+  backup_dir: ~/.dotfiles.backup
+
+dotfile:
+  translate: true
+  package_name_mapping: true
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(content), 0o600))
+
+	cfg, err := config.LoadExtendedFromFile(configPath)
+	require.NoError(t, err)
+
+	assert.Equal(t, filepath.Join(home, ".dotfiles"), cfg.Directories.Package)
+	assert.Equal(t, home, cfg.Directories.Target)
+	assert.Equal(t, filepath.Join(home, ".local/share/dot/manifest"), cfg.Directories.Manifest)
+	assert.Equal(t, filepath.Join(home, ".dotfiles.backup"), cfg.Symlinks.BackupDir)
+	assert.True(t, cfg.Dotfile.PackageNameMapping)
+}
+
+func TestLoader_LoadExpandsPathValues(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `
+directories:
+  package: ~/.dotfiles
+  target: "~"
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(content), 0o600))
+
+	cfg, err := config.NewLoader("dot", configPath).Load()
+	require.NoError(t, err)
+
+	assert.Equal(t, filepath.Join(home, ".dotfiles"), cfg.Directories.Package)
+	assert.Equal(t, home, cfg.Directories.Target)
+}
+
+func TestLoader_LoadWithEnvExpandsPathValues(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("DOT_DIRECTORIES_PACKAGE", "~/env-dotfiles")
+	t.Setenv("DOT_DIRECTORIES_TARGET", "$HOME/env-target")
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `
+directories:
+  package: ~/.dotfiles
+  target: "~"
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(content), 0o600))
+
+	cfg, err := config.NewLoader("dot", configPath).LoadWithEnv()
+	require.NoError(t, err)
+
+	assert.Equal(t, filepath.Join(home, "env-dotfiles"), cfg.Directories.Package)
+	assert.Equal(t, filepath.Join(home, "env-target"), cfg.Directories.Target)
+}
+
+func TestLoader_LoadWithFlagsExpandsPathValues(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `
+directories:
+  package: /absolute/dotfiles
+  target: /absolute/home
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(content), 0o600))
+
+	flags := map[string]interface{}{
+		"dir":    "~/flag-dotfiles",
+		"target": "$HOME/flag-target",
+	}
+
+	cfg, err := config.NewLoader("dot", configPath).LoadWithFlags(flags)
+	require.NoError(t, err)
+
+	assert.Equal(t, filepath.Join(home, "flag-dotfiles"), cfg.Directories.Package)
+	assert.Equal(t, filepath.Join(home, "flag-target"), cfg.Directories.Target)
+}

--- a/internal/config/expand_test.go
+++ b/internal/config/expand_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/yaklabco/dot/internal/config"
+	"gopkg.in/yaml.v3"
 )
 
 func TestExtendedConfig_ExpandPaths(t *testing.T) {
@@ -62,11 +63,6 @@ func TestExtendedConfig_ExpandPaths(t *testing.T) {
 			want:  filepath.Join(home, "outer/inner"),
 		},
 		{
-			name:  "undefined variable expands to empty",
-			value: "$DOT_TEST_UNDEFINED/packages",
-			want:  "/packages",
-		},
-		{
 			name:  "absolute path is unchanged",
 			value: "/etc/dot",
 			want:  "/etc/dot",
@@ -102,7 +98,7 @@ func TestExtendedConfig_ExpandPaths(t *testing.T) {
 			cfg.Symlinks.BackupDir = tt.value
 			cfg.Logging.File = tt.value
 
-			cfg.ExpandPaths()
+			require.NoError(t, cfg.ExpandPaths())
 
 			assert.Equal(t, tt.want, cfg.Directories.Package, "directories.package")
 			assert.Equal(t, tt.want, cfg.Directories.Target, "directories.target")
@@ -122,7 +118,7 @@ func TestExtendedConfig_ExpandPathsLeavesNonPathValues(t *testing.T) {
 	cfg.Ignore.Patterns = []string{"~/*.local", "$HOME/secret"}
 	cfg.Update.Repository = "yaklabco/dot"
 
-	cfg.ExpandPaths()
+	require.NoError(t, cfg.ExpandPaths())
 
 	assert.Equal(t, "~dot-", cfg.Dotfile.Prefix)
 	assert.Equal(t, "$HOME.bak", cfg.Symlinks.BackupSuffix)
@@ -138,12 +134,87 @@ func TestExtendedConfig_ExpandPathsIsIdempotent(t *testing.T) {
 	cfg.Directories.Target = "~"
 	cfg.Directories.Package = "~/.dotfiles"
 
-	cfg.ExpandPaths()
+	require.NoError(t, cfg.ExpandPaths())
 	first := *cfg
-	cfg.ExpandPaths()
+	require.NoError(t, cfg.ExpandPaths())
 
 	assert.Equal(t, first.Directories.Target, cfg.Directories.Target)
 	assert.Equal(t, first.Directories.Package, cfg.Directories.Package)
+}
+
+func TestExtendedConfig_ExpandPathsRejectsUndefinedVariables(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DOT_TEST_ROOT", "/srv/dotfiles")
+
+	tests := []struct {
+		name    string
+		value   string
+		wantVar string
+	}{
+		{
+			name:    "bare undefined variable",
+			value:   "$DOT_TEST_UNDEFINED",
+			wantVar: "$DOT_TEST_UNDEFINED",
+		},
+		{
+			name:    "undefined variable with a suffix",
+			value:   "$DOT_TEST_UNDEFINED/packages",
+			wantVar: "$DOT_TEST_UNDEFINED",
+		},
+		{
+			name:    "braced undefined variable",
+			value:   "${DOT_TEST_UNDEFINED}/packages",
+			wantVar: "$DOT_TEST_UNDEFINED",
+		},
+		{
+			name:    "undefined variable alongside a defined one",
+			value:   "$DOT_TEST_ROOT/$DOT_TEST_UNDEFINED",
+			wantVar: "$DOT_TEST_UNDEFINED",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.DefaultExtended()
+			cfg.Directories.Package = tt.value
+
+			err := cfg.ExpandPaths()
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "directories.package")
+			assert.Contains(t, err.Error(), tt.wantVar)
+			assert.Equal(t, tt.value, cfg.Directories.Package, "value is left as written when expansion fails")
+		})
+	}
+}
+
+func TestExtendedConfig_ExpandPathsReportsUnresolvableHome(t *testing.T) {
+	t.Setenv("HOME", "")
+
+	cfg := config.DefaultExtended()
+	cfg.Directories.Target = "~"
+
+	err := cfg.ExpandPaths()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "directories.target")
+}
+
+func TestLoadExtendedFromFile_RejectsUndefinedVariables(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `
+directories:
+  package: $DOT_TEST_UNDEFINED/repo
+  target: "~"
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(content), 0o600))
+
+	_, err := config.LoadExtendedFromFile(configPath)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "$DOT_TEST_UNDEFINED")
 }
 
 func TestLoadExtendedFromFile_ExpandsPathValues(t *testing.T) {
@@ -332,4 +403,113 @@ directories:
 
 	assert.Equal(t, filepath.Join(home, "flag-dotfiles"), cfg.Directories.Package)
 	assert.Equal(t, filepath.Join(home, "flag-target"), cfg.Directories.Target)
+}
+
+// writtenPaths mirrors the path-typed subset of a written configuration file.
+type writtenPaths struct {
+	Directories struct {
+		Package  string `yaml:"package"`
+		Target   string `yaml:"target"`
+		Manifest string `yaml:"manifest"`
+	} `yaml:"directories"`
+	Symlinks struct {
+		BackupDir string `yaml:"backup_dir"`
+	} `yaml:"symlinks"`
+	Logging struct {
+		Level string `yaml:"level"`
+		File  string `yaml:"file"`
+	} `yaml:"logging"`
+}
+
+func readWrittenPaths(t *testing.T, path string) writtenPaths {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var written writtenPaths
+	require.NoError(t, yaml.Unmarshal(data, &written))
+
+	return written
+}
+
+const portableConfigContent = `
+directories:
+  package: ~/.dotfiles
+  target: "~"
+  manifest: ~/.local/share/dot/manifest
+
+symlinks:
+  backup: true
+  backup_dir: ~/.dotfiles.backup
+
+logging:
+  level: INFO
+  file: ~/.local/state/dot/dot.log
+`
+
+// TestWriter_UpdatePreservesUnexpandedPathValues guards the round trip: a
+// hand-written "~" must survive "dot config set" instead of being frozen into
+// the absolute path of whichever machine happened to run the command.
+func TestWriter_UpdatePreservesUnexpandedPathValues(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(portableConfigContent), 0o600))
+
+	require.NoError(t, config.NewWriter(configPath).Update("logging.level", "DEBUG"))
+
+	written := readWrittenPaths(t, configPath)
+	assert.Equal(t, "~/.dotfiles", written.Directories.Package)
+	assert.Equal(t, "~", written.Directories.Target)
+	assert.Equal(t, "~/.local/share/dot/manifest", written.Directories.Manifest)
+	assert.Equal(t, "~/.dotfiles.backup", written.Symlinks.BackupDir)
+	assert.Equal(t, "~/.local/state/dot/dot.log", written.Logging.File)
+	assert.Equal(t, "DEBUG", written.Logging.Level, "the requested update is applied")
+
+	cfg, err := config.LoadExtendedFromFile(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".dotfiles"), cfg.Directories.Package)
+	assert.Equal(t, home, cfg.Directories.Target)
+}
+
+func TestWriter_UpdatePreservesEnvironmentReferences(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("DOT_TEST_ROOT", filepath.Join(home, "srv"))
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := `
+directories:
+  package: $DOT_TEST_ROOT/packages
+  target: "~"
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(content), 0o600))
+
+	require.NoError(t, config.NewWriter(configPath).Update("logging.level", "DEBUG"))
+
+	written := readWrittenPaths(t, configPath)
+	assert.Equal(t, "$DOT_TEST_ROOT/packages", written.Directories.Package)
+}
+
+// TestUpgradeConfig_PreservesUnexpandedPathValues covers the same round trip
+// through "dot config upgrade", which rewrites the whole file.
+func TestUpgradeConfig_PreservesUnexpandedPathValues(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(portableConfigContent), 0o600))
+
+	_, err := config.UpgradeConfig(configPath, true)
+	require.NoError(t, err)
+
+	written := readWrittenPaths(t, configPath)
+	assert.Equal(t, "~/.dotfiles", written.Directories.Package)
+	assert.Equal(t, "~", written.Directories.Target)
+	assert.Equal(t, "~/.local/share/dot/manifest", written.Directories.Manifest)
+	assert.Equal(t, "~/.dotfiles.backup", written.Symlinks.BackupDir)
+	assert.Equal(t, "~/.local/state/dot/dot.log", written.Logging.File)
 }

--- a/internal/config/extended.go
+++ b/internal/config/extended.go
@@ -319,6 +319,11 @@ func LoadExtendedFromFile(path string) (*ExtendedConfig, error) {
 		return nil, fmt.Errorf("unmarshal config: %w", err)
 	}
 
+	// Resolve "~" and "$VAR" in path values before anything consumes them, so
+	// a config file stays portable across machines instead of creating
+	// directories literally named "~" or "$HOME".
+	cfg.ExpandPaths()
+
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("validate config: %w", err)
 	}

--- a/internal/config/extended.go
+++ b/internal/config/extended.go
@@ -307,6 +307,54 @@ func DefaultExtended() *ExtendedConfig {
 
 // LoadExtendedFromFile loads extended configuration from specified file.
 func LoadExtendedFromFile(path string) (*ExtendedConfig, error) {
+	cfg, err := readExtendedFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Resolve "~" and "$VAR" in path values before anything consumes them, so
+	// a config file stays portable across machines instead of creating
+	// directories literally named "~" or "$HOME".
+	if err := cfg.ExpandPaths(); err != nil {
+		return nil, fmt.Errorf("expand config paths: %w", err)
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("validate config: %w", err)
+	}
+
+	return cfg, nil
+}
+
+// loadExtendedFromFileVerbatim loads extended configuration keeping every path
+// value exactly as it was written.
+//
+// Write-back paths use it: "dot config set" and "dot config upgrade" re-marshal
+// the whole configuration, so loading through LoadExtendedFromFile would freeze
+// a portable "~/.dotfiles" into the absolute path of whichever machine ran the
+// command. Validation still runs against an expanded copy, so a file that
+// LoadExtendedFromFile rejects is rejected here for the same reason.
+func loadExtendedFromFileVerbatim(path string) (*ExtendedConfig, error) {
+	cfg, err := readExtendedFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	expanded := *cfg
+	if err := expanded.ExpandPaths(); err != nil {
+		return nil, fmt.Errorf("expand config paths: %w", err)
+	}
+
+	if err := expanded.Validate(); err != nil {
+		return nil, fmt.Errorf("validate config: %w", err)
+	}
+
+	return cfg, nil
+}
+
+// readExtendedFile decodes a configuration file over the defaults, without
+// expanding or validating it.
+func readExtendedFile(path string) (*ExtendedConfig, error) {
 	v := viper.New()
 	v.SetConfigFile(path)
 
@@ -317,15 +365,6 @@ func LoadExtendedFromFile(path string) (*ExtendedConfig, error) {
 	cfg := DefaultExtended()
 	if err := v.Unmarshal(cfg); err != nil {
 		return nil, fmt.Errorf("unmarshal config: %w", err)
-	}
-
-	// Resolve "~" and "$VAR" in path values before anything consumes them, so
-	// a config file stays portable across machines instead of creating
-	// directories literally named "~" or "$HOME".
-	cfg.ExpandPaths()
-
-	if err := cfg.Validate(); err != nil {
-		return nil, fmt.Errorf("validate config: %w", err)
 	}
 
 	return cfg, nil

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -56,12 +56,16 @@ func (l *Loader) LoadWithEnv() (*ExtendedConfig, error) {
 
 	// Load from environment (sparse config with only env-set values)
 	envCfg := l.loadFromEnv()
-	// Use simple merge for env (only strings, no booleans unless tracked)
-	cfg = mergeConfigs(cfg, envCfg)
 
 	// Environment values carry the same "~" and "$VAR" forms a config file may
-	// use, so expand again after the merge.
-	cfg.ExpandPaths()
+	// use. Expand the overlay before merging, so file values that were already
+	// expanded on load are not run through expansion a second time.
+	if err := envCfg.ExpandPaths(); err != nil {
+		return nil, fmt.Errorf("expand environment configuration: %w", err)
+	}
+
+	// Use simple merge for env (only strings, no booleans unless tracked)
+	cfg = mergeConfigs(cfg, envCfg)
 
 	// Validate merged configuration
 	if err := cfg.Validate(); err != nil {
@@ -82,11 +86,15 @@ func (l *Loader) LoadWithFlags(flags map[string]interface{}) (*ExtendedConfig, e
 
 	// Apply flag overrides
 	flagCfg, verbositySet := l.configFromFlags(flags)
-	cfg = mergeConfigsWithVerbosity(cfg, flagCfg, verbositySet)
 
-	// Flags normally arrive already expanded by the shell, but they can also
-	// come from scripts and tests that pass the literal value through.
-	cfg.ExpandPaths()
+	// Flags normally arrive already expanded by the shell, but a quoted or
+	// script-supplied value reaches us verbatim. Expand the overlay before
+	// merging, for the same reason the environment overlay is expanded first.
+	if err := flagCfg.ExpandPaths(); err != nil {
+		return nil, fmt.Errorf("expand flag configuration: %w", err)
+	}
+
+	cfg = mergeConfigsWithVerbosity(cfg, flagCfg, verbositySet)
 
 	// Validate again after flag overrides
 	if err := cfg.Validate(); err != nil {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -59,6 +59,10 @@ func (l *Loader) LoadWithEnv() (*ExtendedConfig, error) {
 	// Use simple merge for env (only strings, no booleans unless tracked)
 	cfg = mergeConfigs(cfg, envCfg)
 
+	// Environment values carry the same "~" and "$VAR" forms a config file may
+	// use, so expand again after the merge.
+	cfg.ExpandPaths()
+
 	// Validate merged configuration
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
@@ -79,6 +83,10 @@ func (l *Loader) LoadWithFlags(flags map[string]interface{}) (*ExtendedConfig, e
 	// Apply flag overrides
 	flagCfg, verbositySet := l.configFromFlags(flags)
 	cfg = mergeConfigsWithVerbosity(cfg, flagCfg, verbositySet)
+
+	// Flags normally arrive already expanded by the shell, but they can also
+	// come from scripts and tests that pass the literal value through.
+	cfg.ExpandPaths()
 
 	// Validate again after flag overrides
 	if err := cfg.Validate(); err != nil {

--- a/internal/config/operations.go
+++ b/internal/config/operations.go
@@ -19,9 +19,10 @@ func UpgradeConfig(configPath string, force bool) (string, error) {
 		return "", fmt.Errorf("config file does not exist: %s\nRun 'dot config init' to create one", configPath)
 	}
 
-	// Load existing config
-	loader := NewLoader("dot", configPath)
-	oldConfig, err := loader.LoadWithEnv()
+	// Load existing config verbatim: the upgrade rewrites the whole file, so
+	// an expanded load would bake this machine's absolute paths, and any
+	// DOT_* override in the current environment, into the user's config.
+	oldConfig, err := loadExtendedFromFileVerbatim(configPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to load existing config: %w", err)
 	}

--- a/internal/config/writer.go
+++ b/internal/config/writer.go
@@ -57,7 +57,10 @@ func (w *Writer) Update(key string, value interface{}) error {
 	var err error
 
 	if fileExists(w.path) {
-		cfg, err = LoadExtendedFromFile(w.path)
+		// Load verbatim: this config is written straight back out, and an
+		// expanded load would replace a hand-written "~" or "$VAR" with this
+		// machine's absolute path.
+		cfg, err = loadExtendedFromFileVerbatim(w.path)
 		if err != nil {
 			return fmt.Errorf("load existing config: %w", err)
 		}


### PR DESCRIPTION
Adds flake.nix (buildGoModule, four systems, vendorHash validated by a real nix build on a NixOS host), expands tilde and environment variables in path-typed config values (Refs #80), and rewrites repository-config.md, 04-configuration.md, migration-from-stow.md, and README so the name-mapped and full-tree layouts are documented as first-class peers.