### PR TITLE
fix(version): report ldflags or module version instead of unknown

### DIFF
--- a/cmd/dot/main.go
+++ b/cmd/dot/main.go
@@ -47,10 +47,13 @@ func run() int {
 	doctorResult := &DoctorResultHolder{}
 	ctx = WithDoctorResultHolder(ctx, doctorResult)
 
-	rootCmd := NewRootCommand(version, commit, date)
+	resolvedVersion := resolveVersion(version)
+	rootCmd := NewRootCommand(resolvedVersion, commit, date)
 
-	// Execute command with fang for enhanced output
-	err := fang.Execute(ctx, rootCmd)
+	// Execute command with fang for enhanced output. Fang derives its own
+	// --version from build info and ignores cobra's Version field, so the
+	// resolved version must be passed explicitly (issue #85).
+	err := fang.Execute(ctx, rootCmd, fang.WithVersion(resolvedVersion))
 	if err != nil {
 		return 1
 	}

--- a/cmd/dot/version_resolve.go
+++ b/cmd/dot/version_resolve.go
@@ -1,0 +1,31 @@
+package main
+
+import "runtime/debug"
+
+// effectiveVersion resolves the version reported by dot --version.
+//
+// Precedence: an ldflags-stamped version (goreleaser and Makefile builds)
+// wins; otherwise the module version embedded by the Go toolchain covers
+// go install builds; a source build inside the repo, where the module
+// version is "(devel)", degrades to "dev".
+func effectiveVersion(ldflagsVersion string, info *debug.BuildInfo) string {
+	if ldflagsVersion != "" && ldflagsVersion != "dev" {
+		return ldflagsVersion
+	}
+	if info != nil && info.Main.Version != "" && info.Main.Version != "(devel)" {
+		return info.Main.Version
+	}
+	if ldflagsVersion == "" {
+		return "dev"
+	}
+	return ldflagsVersion
+}
+
+// resolveVersion applies effectiveVersion to the running binary's build info.
+func resolveVersion(ldflagsVersion string) string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		info = nil
+	}
+	return effectiveVersion(ldflagsVersion, info)
+}

--- a/cmd/dot/version_resolve_test.go
+++ b/cmd/dot/version_resolve_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestEffectiveVersion(t *testing.T) {
+	t.Parallel()
+
+	buildInfo := func(v string) *debug.BuildInfo {
+		return &debug.BuildInfo{Main: debug.Module{Version: v}}
+	}
+
+	tests := []struct {
+		name    string
+		ldflags string
+		info    *debug.BuildInfo
+		want    string
+	}{
+		{
+			name:    "ldflags stamped version wins",
+			ldflags: "v0.7.0",
+			info:    buildInfo("v0.6.6"),
+			want:    "v0.7.0",
+		},
+		{
+			name:    "go install build falls back to module version",
+			ldflags: "dev",
+			info:    buildInfo("v0.6.6"),
+			want:    "v0.6.6",
+		},
+		{
+			name:    "source build in repo reports dev",
+			ldflags: "dev",
+			info:    buildInfo("(devel)"),
+			want:    "dev",
+		},
+		{
+			name:    "missing build info reports dev",
+			ldflags: "dev",
+			info:    nil,
+			want:    "dev",
+		},
+		{
+			name:    "empty ldflags with module version",
+			ldflags: "",
+			info:    buildInfo("v0.6.6"),
+			want:    "v0.6.6",
+		},
+		{
+			name:    "empty everything degrades to dev",
+			ldflags: "",
+			info:    &debug.BuildInfo{},
+			want:    "dev",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := effectiveVersion(tt.ldflags, tt.info)
+			if got != tt.want {
+				t.Errorf("effectiveVersion(%q, ...) = %q, want %q", tt.ldflags, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fang derives --version from build info and ignores cobra Version, so stamped release builds printed unknown (built from source). Resolve the version once (ldflags wins, module version covers go install builds, source builds degrade to dev) and pass it to fang explicitly.

Fixes #85