### PR TITLE
feat(planner): reject duplicate target paths across packages

### DIFF
--- a/cmd/dot/clone.go
+++ b/cmd/dot/clone.go
@@ -189,7 +189,9 @@ func formatCloneError(err error) error {
 		return fmt.Errorf("%w\n\nCheck available profiles in .dotbootstrap.yaml", profileNotFound)
 	}
 
-	return err
+	// Cloned repositories can carry packages that overlap; those collisions
+	// come with their own remediation guidance.
+	return withRemediation(err)
 }
 
 // extractRepoName extracts the repository name from a URL.

--- a/cmd/dot/command_helpers.go
+++ b/cmd/dot/command_helpers.go
@@ -17,6 +17,39 @@ import (
 // packageCommandFunc is a function that executes a package operation.
 type packageCommandFunc func(*dot.Client, context.Context, []string) error
 
+// targetCollision presents a target collision using the remediation guidance
+// the domain defines for it, while keeping the underlying typed error
+// matchable through errors.As and errors.Is.
+type targetCollision struct {
+	err error
+}
+
+func (e targetCollision) Error() string { return dot.UserFacingError(e.err) }
+
+func (e targetCollision) Unwrap() error { return e.err }
+
+// withRemediation swaps a target collision for its user-facing presentation.
+// Every other error is returned untouched, so existing wording is unchanged.
+func withRemediation(err error) error {
+	var duplicate dot.ErrDuplicateTarget
+	if errors.As(err, &duplicate) {
+		return targetCollision{err: duplicate}
+	}
+
+	var kindConflict dot.ErrTargetKindConflict
+	if errors.As(err, &kindConflict) {
+		return targetCollision{err: kindConflict}
+	}
+
+	return err
+}
+
+// printCommandError writes a failed command's error to stderr, adding
+// remediation guidance where the error type carries some.
+func printCommandError(cmd *cobra.Command, err error) {
+	fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", withRemediation(err))
+}
+
 // executePackageCommand is a helper that handles the common pattern for package commands.
 // It builds the config, creates a client, executes the provided function, and prints success message.
 func executePackageCommand(cmd *cobra.Command, args []string, fn packageCommandFunc, actionVerb string) error {
@@ -45,7 +78,7 @@ func executePackageCommand(cmd *cobra.Command, args []string, fn packageCommandF
 			formatNoChangesMessage(cmd.OutOrStdout(), len(packages), shouldUseColor())
 			return nil
 		}
-		fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
+		printCommandError(cmd, err)
 		return err
 	}
 

--- a/cmd/dot/duplicate_target_test.go
+++ b/cmd/dot/duplicate_target_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// duplicateTargetSandbox builds a self-contained package/target/manifest tree
+// where two packages claim the same target path. Nothing outside the sandbox is
+// read or written: the package directory carries its own config, and every
+// directory is passed explicitly.
+func duplicateTargetSandbox(t *testing.T) (packageDir, targetDir string) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	packageDir = filepath.Join(tmpDir, "packages")
+	targetDir = filepath.Join(tmpDir, "target")
+	manifestDir := filepath.Join(tmpDir, "manifest")
+
+	for _, dir := range []string{packageDir, targetDir, manifestDir} {
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+	}
+
+	// Two packages, same relative file: with the stow-style full-tree layout
+	// both resolve to <target>/.vimrc.
+	for _, pkg := range []string{"base", "overlay"} {
+		pkgDir := filepath.Join(packageDir, pkg)
+		require.NoError(t, os.MkdirAll(pkgDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "dot-vimrc"), []byte(pkg), 0o644))
+	}
+
+	// Repository-local config keeps the run away from the real home directory
+	// and disables package name mapping so the two packages overlap.
+	configDir := filepath.Join(packageDir, ".config", "dot")
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+	config := fmt.Sprintf(`directories:
+  package: %s
+  target: %s
+  manifest: %s
+dotfile:
+  translate: true
+  package_name_mapping: false
+`, packageDir, targetDir, manifestDir)
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(config), 0o644))
+
+	return packageDir, targetDir
+}
+
+// TestDuplicateTargetAcrossPackages_CLISurface checks the message a user sees
+// when two packages fight over the same target path.
+//
+// Only manage is covered here. clone routes through ManageService.Manage with
+// the full package list, so it hits the same guard, while remanage plans each
+// package in isolation and never builds one shared desired state.
+func TestDuplicateTargetAcrossPackages_CLISurface(t *testing.T) {
+	tests := []struct {
+		name    string
+		command func() *cobra.Command
+	}{
+		{name: "manage", command: newManageCommand},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			packageDir, targetDir := duplicateTargetSandbox(t)
+
+			setupIntegrationTestFlags(t, CLIFlags{
+				packageDir: packageDir,
+				targetDir:  targetDir,
+			})
+
+			var stderr bytes.Buffer
+			cmd := tt.command()
+			cmd.SetContext(context.Background())
+			cmd.SetArgs([]string{"base", "overlay"})
+			cmd.SetOut(&stderr)
+			cmd.SetErr(&stderr)
+
+			err := cmd.Execute()
+			require.Error(t, err, "overlapping packages must not be planned silently")
+
+			for _, want := range []string{filepath.Join(targetDir, ".vimrc"), "base", "overlay"} {
+				assert.Contains(t, err.Error(), want)
+				assert.Contains(t, stderr.String(), want)
+			}
+
+			// Planning failed, so nothing was linked.
+			_, statErr := os.Lstat(filepath.Join(targetDir, ".vimrc"))
+			assert.True(t, os.IsNotExist(statErr), "no link should be created when planning fails")
+		})
+	}
+}
+
+func TestDuplicateTargetAcrossPackages_DryRunAlsoFails(t *testing.T) {
+	packageDir, targetDir := duplicateTargetSandbox(t)
+
+	setupIntegrationTestFlags(t, CLIFlags{
+		packageDir: packageDir,
+		targetDir:  targetDir,
+		dryRun:     true,
+	})
+
+	var stderr bytes.Buffer
+	cmd := newManageCommand()
+	cmd.SetContext(context.Background())
+	cmd.SetArgs([]string{"base", "overlay"})
+	cmd.SetOut(&stderr)
+	cmd.SetErr(&stderr)
+
+	err := cmd.Execute()
+	require.Error(t, err, "dry run must report the collision rather than a plan")
+	assert.Contains(t, err.Error(), "base")
+	assert.Contains(t, err.Error(), "overlay")
+}
+
+func TestSinglePackageStillManages(t *testing.T) {
+	packageDir, targetDir := duplicateTargetSandbox(t)
+
+	setupIntegrationTestFlags(t, CLIFlags{
+		packageDir: packageDir,
+		targetDir:  targetDir,
+	})
+
+	cmd := newManageCommand()
+	cmd.SetContext(context.Background())
+	cmd.SetArgs([]string{"base"})
+
+	require.NoError(t, cmd.Execute())
+	assert.FileExists(t, filepath.Join(targetDir, ".vimrc"))
+}

--- a/cmd/dot/duplicate_target_test.go
+++ b/cmd/dot/duplicate_target_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -57,46 +56,66 @@ dotfile:
 // TestDuplicateTargetAcrossPackages_CLISurface checks the message a user sees
 // when two packages fight over the same target path.
 //
-// Only manage is covered here. clone routes through ManageService.Manage with
-// the full package list, so it hits the same guard, while remanage plans each
-// package in isolation and never builds one shared desired state.
+// clone routes through ManageService.Manage with the full package list, so it
+// hits the same guard as manage; remanage plans each package on its own and is
+// guarded separately in pkg/dot.
 func TestDuplicateTargetAcrossPackages_CLISurface(t *testing.T) {
-	tests := []struct {
-		name    string
-		command func() *cobra.Command
-	}{
-		{name: "manage", command: newManageCommand},
+	packageDir, targetDir := duplicateTargetSandbox(t)
+
+	setupIntegrationTestFlags(t, CLIFlags{
+		packageDir: packageDir,
+		targetDir:  targetDir,
+	})
+
+	var out bytes.Buffer
+	cmd := newManageCommand()
+	cmd.SetContext(context.Background())
+	cmd.SetArgs([]string{"base", "overlay"})
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	err := cmd.Execute()
+	require.Error(t, err, "overlapping packages must not be planned silently")
+
+	for _, want := range []string{filepath.Join(targetDir, ".vimrc"), "base", "overlay"} {
+		assert.Contains(t, err.Error(), want)
+		assert.Contains(t, out.String(), want)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			packageDir, targetDir := duplicateTargetSandbox(t)
+	// The printed message must tell the user what to do about it, not just
+	// state that the collision happened.
+	assert.Contains(t, out.String(), "Remove the file from one package")
+	assert.Contains(t, out.String(), "package_name_mapping")
 
-			setupIntegrationTestFlags(t, CLIFlags{
-				packageDir: packageDir,
-				targetDir:  targetDir,
-			})
+	// Planning failed, so nothing was linked.
+	_, statErr := os.Lstat(filepath.Join(targetDir, ".vimrc"))
+	assert.True(t, os.IsNotExist(statErr), "no link should be created when planning fails")
+}
 
-			var stderr bytes.Buffer
-			cmd := tt.command()
-			cmd.SetContext(context.Background())
-			cmd.SetArgs([]string{"base", "overlay"})
-			cmd.SetOut(&stderr)
-			cmd.SetErr(&stderr)
+// TestDuplicateTargetAcrossPackages_RemanageCLISurface covers the remanage
+// path, which plans each package separately.
+func TestDuplicateTargetAcrossPackages_RemanageCLISurface(t *testing.T) {
+	packageDir, targetDir := duplicateTargetSandbox(t)
 
-			err := cmd.Execute()
-			require.Error(t, err, "overlapping packages must not be planned silently")
+	setupIntegrationTestFlags(t, CLIFlags{
+		packageDir: packageDir,
+		targetDir:  targetDir,
+	})
 
-			for _, want := range []string{filepath.Join(targetDir, ".vimrc"), "base", "overlay"} {
-				assert.Contains(t, err.Error(), want)
-				assert.Contains(t, stderr.String(), want)
-			}
+	var out bytes.Buffer
+	cmd := newRemanageCommand()
+	cmd.SetContext(context.Background())
+	cmd.SetArgs([]string{"base", "overlay"})
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
 
-			// Planning failed, so nothing was linked.
-			_, statErr := os.Lstat(filepath.Join(targetDir, ".vimrc"))
-			assert.True(t, os.IsNotExist(statErr), "no link should be created when planning fails")
-		})
+	err := cmd.Execute()
+	require.Error(t, err, "overlapping packages must not be remanaged silently")
+
+	for _, want := range []string{filepath.Join(targetDir, ".vimrc"), "base", "overlay"} {
+		assert.Contains(t, err.Error(), want)
 	}
+	assert.Contains(t, out.String(), "Remove the file from one package")
 }
 
 func TestDuplicateTargetAcrossPackages_DryRunAlsoFails(t *testing.T) {

--- a/cmd/dot/manage.go
+++ b/cmd/dot/manage.go
@@ -81,7 +81,7 @@ func runManage(cmd *cobra.Command, args []string) error {
 	if cfg.DryRun {
 		plan, err := client.PlanManage(ctx, packages...)
 		if err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
+			printCommandError(cmd, err)
 			return err
 		}
 
@@ -111,7 +111,7 @@ func runManage(cmd *cobra.Command, args []string) error {
 			formatNoChangesMessage(cmd.OutOrStdout(), len(packages), shouldUseColor())
 			return nil
 		}
-		fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
+		printCommandError(cmd, err)
 		return err
 	}
 

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -36,6 +36,34 @@ func (e ErrConflict) Error() string {
 	return fmt.Sprintf("conflict at %q: %s", e.Path, e.Reason)
 }
 
+// ErrDuplicateTarget indicates two different packages want to link the same
+// target path. Planning stops rather than letting the last package walked
+// silently win.
+type ErrDuplicateTarget struct {
+	TargetPath    string
+	FirstPackage  string
+	SecondPackage string
+}
+
+func (e ErrDuplicateTarget) Error() string {
+	return fmt.Sprintf("duplicate target %q: claimed by package %q and package %q",
+		e.TargetPath, e.FirstPackage, e.SecondPackage)
+}
+
+// ErrTargetKindConflict indicates one package wants a target path to be a
+// symlink to a file while another package needs the same path to be a parent
+// directory holding its own links.
+type ErrTargetKindConflict struct {
+	TargetPath  string
+	FilePackage string
+	DirPackage  string
+}
+
+func (e ErrTargetKindConflict) Error() string {
+	return fmt.Sprintf("conflicting target %q: package %q links it as a file, package %q needs it as a directory",
+		e.TargetPath, e.FilePackage, e.DirPackage)
+}
+
 // ErrCyclicDependency indicates a circular dependency in operations.
 type ErrCyclicDependency struct {
 	Cycle []string
@@ -219,18 +247,39 @@ func (e ErrMultiple) Unwrap() []error {
 
 // User-Facing Error Messages
 
+// userFacingConflict renders the errors raised when two things want the same
+// target path. Grouped here so UserFacingError keeps a flat, readable switch.
+func userFacingConflict(err error) (string, bool) {
+	switch e := err.(type) {
+	case ErrConflict:
+		return fmt.Sprintf("Cannot proceed: conflict at %q\n%s", e.Path, e.Reason), true
+
+	case ErrDuplicateTarget:
+		return fmt.Sprintf("Cannot proceed: packages %q and %q both want to manage %q.\nRemove the file from one package, or keep the packages apart by enabling dotfile.package_name_mapping.",
+			e.FirstPackage, e.SecondPackage, e.TargetPath), true
+
+	case ErrTargetKindConflict:
+		return fmt.Sprintf("Cannot proceed: package %q wants %q to be a link to a file, but package %q needs it to be a directory.\nRename or remove one of the two entries so the packages no longer overlap.",
+			e.FilePackage, e.TargetPath, e.DirPackage), true
+
+	default:
+		return "", false
+	}
+}
+
 // UserFacingError converts an error into a user-friendly message.
 // Removes technical jargon and provides actionable information.
 func UserFacingError(err error) string {
+	if msg, ok := userFacingConflict(err); ok {
+		return msg
+	}
+
 	switch e := err.(type) {
 	case ErrPackageNotFound:
 		return fmt.Sprintf("Package %q not found. Check that the package exists in your package directory.", e.Package)
 
 	case ErrInvalidPath:
 		return fmt.Sprintf("Invalid path %q: %s", e.Path, e.Reason)
-
-	case ErrConflict:
-		return fmt.Sprintf("Cannot proceed: conflict at %q\n%s", e.Path, e.Reason)
 
 	case ErrCyclicDependency:
 		return fmt.Sprintf("Circular dependency detected in operations: %s", strings.Join(e.Cycle, " → "))

--- a/internal/domain/errors_duplicate_target_test.go
+++ b/internal/domain/errors_duplicate_target_test.go
@@ -1,0 +1,70 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yaklabco/dot/internal/domain"
+)
+
+func TestErrDuplicateTarget(t *testing.T) {
+	err := domain.ErrDuplicateTarget{
+		TargetPath:    "/home/user/.vimrc",
+		FirstPackage:  "base",
+		SecondPackage: "overlay",
+	}
+
+	msg := err.Error()
+	assert.Contains(t, msg, "/home/user/.vimrc")
+	assert.Contains(t, msg, "base")
+	assert.Contains(t, msg, "overlay")
+}
+
+func TestErrTargetKindConflict(t *testing.T) {
+	err := domain.ErrTargetKindConflict{
+		TargetPath:  "/home/user/.config",
+		FilePackage: "base",
+		DirPackage:  "overlay",
+	}
+
+	msg := err.Error()
+	assert.Contains(t, msg, "/home/user/.config")
+	assert.Contains(t, msg, "base")
+	assert.Contains(t, msg, "overlay")
+}
+
+func TestUserFacingErrorForTargetCollisions(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		contains []string
+	}{
+		{
+			name: "duplicate target names both packages and the path",
+			err: domain.ErrDuplicateTarget{
+				TargetPath:    "/home/user/.vimrc",
+				FirstPackage:  "base",
+				SecondPackage: "overlay",
+			},
+			contains: []string{"/home/user/.vimrc", "base", "overlay"},
+		},
+		{
+			name: "target kind conflict names both packages and the path",
+			err: domain.ErrTargetKindConflict{
+				TargetPath:  "/home/user/.config",
+				FilePackage: "base",
+				DirPackage:  "overlay",
+			},
+			contains: []string{"/home/user/.config", "base", "overlay"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := domain.UserFacingError(tt.err)
+			for _, want := range tt.contains {
+				assert.Contains(t, msg, want)
+			}
+		})
+	}
+}

--- a/internal/planner/desired.go
+++ b/internal/planner/desired.go
@@ -11,13 +11,15 @@ import (
 
 // LinkSpec specifies a desired symbolic link.
 type LinkSpec struct {
-	Source domain.FilePath   // Source file in package
-	Target domain.TargetPath // Target location
+	Source  domain.FilePath   // Source file in package
+	Target  domain.TargetPath // Target location
+	Package string            // Name of the package that claimed this target
 }
 
 // DirSpec specifies a desired directory.
 type DirSpec struct {
-	Path domain.FilePath
+	Path    domain.FilePath
+	Package string // Name of the package that first required this directory
 }
 
 // DesiredState represents the desired filesystem state.
@@ -42,12 +44,20 @@ func (pr PlanResult) HasConflicts() bool {
 // should exist based on the package contents.
 //
 // For each file in each package:
-// 1. Compute relative path from package root
-// 2. Apply dotfile translation (dot-vimrc -> .vimrc)
-// 3. If packageNameMapping enabled, prepend translated package name
-// 4. Join with target to get target path
-// 5. Create LinkSpec (source -> target)
-// 6. Create DirSpec for parent directories
+//  1. Compute relative path from package root
+//  2. Apply dotfile translation (dot-vimrc -> .vimrc)
+//  3. If packageNameMapping is enabled, prepend the translated package name;
+//     otherwise use the stow-style full-tree layout, where the package tree
+//     maps straight onto the target
+//  4. Join with target to get target path
+//  5. Create LinkSpec (source -> target)
+//  6. Create DirSpec for parent directories
+//
+// Every target path is owned by exactly one package. If a second, different
+// package claims a path that is already claimed, planning fails with
+// domain.ErrDuplicateTarget (same path, both as links) or
+// domain.ErrTargetKindConflict (one package links a file where another needs a
+// directory) rather than letting the last package walked silently win.
 func ComputeDesiredState(packages []domain.Package, target domain.TargetPath, packageNameMapping bool, translate ...bool) domain.Result[DesiredState] {
 	// Default translate to true for backward compatibility
 	doTranslate := true
@@ -108,18 +118,19 @@ func walkPackageFiles(node domain.Node, pkgRoot domain.PackagePath, pkgName stri
 			combinedPath := filepath.Join(translatedPkgName, translated)
 			targetPath = target.Join(combinedPath)
 		} else {
-			// Legacy behavior: no package name mapping
+			// Stow-style full-tree layout: the package tree maps straight onto
+			// the target, so paths are relative to the package root and the
+			// package name never appears in the target path.
 			targetPath = target.Join(translated)
 		}
 
-		// Add link spec
-		state.Links[targetPath.String()] = LinkSpec{
-			Source: node.Path,
-			Target: targetPath,
+		// Claim the target path for this package, rejecting cross-package collisions
+		if err := claimLinkTarget(state, targetPath, node.Path, pkgName); err != nil {
+			return err
 		}
 
 		// Add parent directory specs
-		if err := addParentDirs(targetPath, target, state); err != nil {
+		if err := addParentDirs(targetPath, target, pkgName, state); err != nil {
 			return err
 		}
 	}
@@ -134,8 +145,44 @@ func walkPackageFiles(node domain.Node, pkgRoot domain.PackagePath, pkgName stri
 	return nil
 }
 
+// claimLinkTarget records a link spec for pkgName at targetPath.
+//
+// A target path may only be claimed by one package. Re-walking the same package,
+// or a package claiming the same path twice, is a no-op rather than an error.
+func claimLinkTarget(state *DesiredState, targetPath domain.TargetPath, source domain.FilePath, pkgName string) error {
+	key := targetPath.String()
+
+	if existing, claimed := state.Links[key]; claimed && existing.Package != pkgName {
+		return domain.ErrDuplicateTarget{
+			TargetPath:    key,
+			FirstPackage:  existing.Package,
+			SecondPackage: pkgName,
+		}
+	}
+
+	// Another package already needs this path as a directory holding its links.
+	if dir, claimed := state.Dirs[key]; claimed && dir.Package != pkgName {
+		return domain.ErrTargetKindConflict{
+			TargetPath:  key,
+			FilePackage: pkgName,
+			DirPackage:  dir.Package,
+		}
+	}
+
+	state.Links[key] = LinkSpec{
+		Source:  source,
+		Target:  targetPath,
+		Package: pkgName,
+	}
+
+	return nil
+}
+
 // addParentDirs adds directory specs for all parent directories of path.
-func addParentDirs(path domain.TargetPath, target domain.TargetPath, state *DesiredState) error {
+// Directories may be shared between packages; only the first claimant is
+// recorded, so that two packages placing distinct files in the same directory
+// create it once.
+func addParentDirs(path domain.TargetPath, target domain.TargetPath, pkgName string, state *DesiredState) error {
 	current := path
 	targetStr := target.String()
 
@@ -153,6 +200,15 @@ func addParentDirs(path domain.TargetPath, target domain.TargetPath, state *Desi
 			break
 		}
 
+		// Another package already links this exact path as a file
+		if link, claimed := state.Links[parentStr]; claimed && link.Package != pkgName {
+			return domain.ErrTargetKindConflict{
+				TargetPath:  parentStr,
+				FilePackage: link.Package,
+				DirPackage:  pkgName,
+			}
+		}
+
 		// Add directory spec if not already present
 		if _, exists := state.Dirs[parentStr]; !exists {
 			// Convert TargetPath to FilePath for DirSpec storage
@@ -161,7 +217,7 @@ func addParentDirs(path domain.TargetPath, target domain.TargetPath, state *Desi
 				return fmt.Errorf("invalid path %s: %w", parentStr, dirPathResult.UnwrapErr())
 			}
 			dirPath := dirPathResult.Unwrap()
-			state.Dirs[parentStr] = DirSpec{Path: dirPath}
+			state.Dirs[parentStr] = DirSpec{Path: dirPath, Package: pkgName}
 		}
 
 		current = parent

--- a/internal/planner/desired_duplicate_test.go
+++ b/internal/planner/desired_duplicate_test.go
@@ -1,0 +1,287 @@
+package planner_test
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklabco/dot/internal/domain"
+	"github.com/yaklabco/dot/internal/planner"
+)
+
+// buildTestPackage builds a package whose tree contains the given files,
+// expressed as slash separated paths relative to the package root.
+func buildTestPackage(t *testing.T, root, name string, files ...string) domain.Package {
+	t.Helper()
+
+	rootNode := domain.Node{
+		Path: domain.NewFilePath(root).Unwrap(),
+		Type: domain.NodeDir,
+	}
+
+	for _, rel := range files {
+		insertTestFile(t, &rootNode, root, rel)
+	}
+
+	pkgPath := domain.NewPackagePath(root)
+	require.True(t, pkgPath.IsOk(), "package path %s must be valid", root)
+
+	return domain.Package{
+		Name: name,
+		Path: pkgPath.Unwrap(),
+		Tree: &rootNode,
+	}
+}
+
+// insertTestFile inserts rel into the tree rooted at parent, creating
+// intermediate directory nodes as needed.
+func insertTestFile(t *testing.T, parent *domain.Node, parentPath, rel string) {
+	t.Helper()
+
+	segments := strings.Split(rel, "/")
+	current := parent
+	currentPath := parentPath
+
+	for i, segment := range segments {
+		currentPath = filepath.Join(currentPath, segment)
+
+		nodeType := domain.NodeDir
+		if i == len(segments)-1 {
+			nodeType = domain.NodeFile
+		}
+
+		child := findTestChild(current, currentPath)
+		if child == nil {
+			current.Children = append(current.Children, domain.Node{
+				Path: domain.NewFilePath(currentPath).Unwrap(),
+				Type: nodeType,
+			})
+			child = &current.Children[len(current.Children)-1]
+		}
+
+		current = child
+	}
+}
+
+func findTestChild(parent *domain.Node, path string) *domain.Node {
+	for i := range parent.Children {
+		if parent.Children[i].Path.String() == path {
+			return &parent.Children[i]
+		}
+	}
+	return nil
+}
+
+func TestComputeDesiredState_DuplicateTargetAcrossPackages(t *testing.T) {
+	target := domain.NewTargetPath("/home/user").Unwrap()
+
+	tests := []struct {
+		name          string
+		packages      []domain.Package
+		wantPath      string
+		wantFirstPkg  string
+		wantSecondPkg string
+	}{
+		{
+			name: "two packages claim the same top level file",
+			packages: []domain.Package{
+				buildTestPackage(t, "/dotfiles/base", "base", "dot-vimrc"),
+				buildTestPackage(t, "/dotfiles/overlay", "overlay", "dot-vimrc"),
+			},
+			wantPath:      "/home/user/.vimrc",
+			wantFirstPkg:  "base",
+			wantSecondPkg: "overlay",
+		},
+		{
+			name: "two packages claim the same nested file",
+			packages: []domain.Package{
+				buildTestPackage(t, "/dotfiles/base", "base", "dot-config/nvim/init.lua"),
+				buildTestPackage(t, "/dotfiles/overlay", "overlay", "dot-config/nvim/init.lua"),
+			},
+			wantPath:      "/home/user/.config/nvim/init.lua",
+			wantFirstPkg:  "base",
+			wantSecondPkg: "overlay",
+		},
+		{
+			name: "collision only after dotfile translation",
+			packages: []domain.Package{
+				buildTestPackage(t, "/dotfiles/base", "base", "dot-gitconfig"),
+				buildTestPackage(t, "/dotfiles/overlay", "overlay", ".gitconfig"),
+			},
+			wantPath:      "/home/user/.gitconfig",
+			wantFirstPkg:  "base",
+			wantSecondPkg: "overlay",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := planner.ComputeDesiredState(tt.packages, target, false)
+			require.True(t, result.IsErr(), "expected duplicate target to be rejected")
+
+			err := result.UnwrapErr()
+
+			var dup domain.ErrDuplicateTarget
+			require.True(t, errors.As(err, &dup), "expected ErrDuplicateTarget, got %T", err)
+			assert.Equal(t, tt.wantPath, dup.TargetPath)
+			assert.Equal(t, tt.wantFirstPkg, dup.FirstPackage)
+			assert.Equal(t, tt.wantSecondPkg, dup.SecondPackage)
+
+			msg := err.Error()
+			assert.Contains(t, msg, tt.wantPath)
+			assert.Contains(t, msg, tt.wantFirstPkg)
+			assert.Contains(t, msg, tt.wantSecondPkg)
+		})
+	}
+}
+
+func TestComputeDesiredState_SamePackageClaimingTwiceIsAllowed(t *testing.T) {
+	target := domain.NewTargetPath("/home/user").Unwrap()
+	pkg := buildTestPackage(t, "/dotfiles/base", "base", "dot-vimrc")
+
+	tests := []struct {
+		name     string
+		packages []domain.Package
+	}{
+		{
+			name:     "package walked once",
+			packages: []domain.Package{pkg},
+		},
+		{
+			name:     "identical package walked twice",
+			packages: []domain.Package{pkg, pkg},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := planner.ComputeDesiredState(tt.packages, target, false)
+			require.True(t, result.IsOk(), "expected no error")
+
+			state := result.Unwrap()
+			require.Len(t, state.Links, 1)
+
+			link, ok := state.Links["/home/user/.vimrc"]
+			require.True(t, ok)
+			assert.Equal(t, "base", link.Package)
+		})
+	}
+}
+
+func TestComputeDesiredState_DistinctFilesInSharedDirectory(t *testing.T) {
+	target := domain.NewTargetPath("/home/user").Unwrap()
+
+	packages := []domain.Package{
+		buildTestPackage(t, "/dotfiles/base", "base", "dot-config/shell/aliases"),
+		buildTestPackage(t, "/dotfiles/overlay", "overlay", "dot-config/shell/functions"),
+	}
+
+	result := planner.ComputeDesiredState(packages, target, false)
+	require.True(t, result.IsOk(), "packages sharing a directory must not collide")
+
+	state := result.Unwrap()
+	require.Len(t, state.Links, 2)
+
+	aliases, ok := state.Links["/home/user/.config/shell/aliases"]
+	require.True(t, ok)
+	assert.Equal(t, "base", aliases.Package)
+
+	functions, ok := state.Links["/home/user/.config/shell/functions"]
+	require.True(t, ok)
+	assert.Equal(t, "overlay", functions.Package)
+
+	// The shared parent directories are recorded exactly once each.
+	require.Len(t, state.Dirs, 2)
+	assert.Contains(t, state.Dirs, "/home/user/.config")
+	assert.Contains(t, state.Dirs, "/home/user/.config/shell")
+	assert.Equal(t, "base", state.Dirs["/home/user/.config/shell"].Package)
+}
+
+func TestComputeDesiredState_DirectoryFileCollisionAcrossPackages(t *testing.T) {
+	target := domain.NewTargetPath("/home/user").Unwrap()
+
+	tests := []struct {
+		name        string
+		packages    []domain.Package
+		wantPath    string
+		wantFilePkg string
+		wantDirPkg  string
+	}{
+		{
+			name: "file claimed before directory",
+			packages: []domain.Package{
+				buildTestPackage(t, "/dotfiles/base", "base", "dot-config"),
+				buildTestPackage(t, "/dotfiles/overlay", "overlay", "dot-config/nvim/init.lua"),
+			},
+			wantPath:    "/home/user/.config",
+			wantFilePkg: "base",
+			wantDirPkg:  "overlay",
+		},
+		{
+			name: "directory claimed before file",
+			packages: []domain.Package{
+				buildTestPackage(t, "/dotfiles/overlay", "overlay", "dot-config/nvim/init.lua"),
+				buildTestPackage(t, "/dotfiles/base", "base", "dot-config"),
+			},
+			wantPath:    "/home/user/.config",
+			wantFilePkg: "base",
+			wantDirPkg:  "overlay",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := planner.ComputeDesiredState(tt.packages, target, false)
+			require.True(t, result.IsErr(), "expected directory/file collision to be rejected")
+
+			err := result.UnwrapErr()
+
+			var collision domain.ErrTargetKindConflict
+			require.True(t, errors.As(err, &collision), "expected ErrTargetKindConflict, got %T", err)
+			assert.Equal(t, tt.wantPath, collision.TargetPath)
+			assert.Equal(t, tt.wantFilePkg, collision.FilePackage)
+			assert.Equal(t, tt.wantDirPkg, collision.DirPackage)
+
+			msg := err.Error()
+			assert.Contains(t, msg, tt.wantPath)
+			assert.Contains(t, msg, tt.wantFilePkg)
+			assert.Contains(t, msg, tt.wantDirPkg)
+		})
+	}
+}
+
+func TestComputeDesiredState_PackageNameMappingKeepsPackagesDisjoint(t *testing.T) {
+	target := domain.NewTargetPath("/home/user").Unwrap()
+
+	packages := []domain.Package{
+		buildTestPackage(t, "/dotfiles/base", "base", "dot-vimrc"),
+		buildTestPackage(t, "/dotfiles/overlay", "overlay", "dot-vimrc"),
+	}
+
+	result := planner.ComputeDesiredState(packages, target, true)
+	require.True(t, result.IsOk(), "package name mapping gives each package its own subtree")
+
+	state := result.Unwrap()
+	require.Len(t, state.Links, 2)
+	assert.Contains(t, state.Links, "/home/user/base/.vimrc")
+	assert.Contains(t, state.Links, "/home/user/overlay/.vimrc")
+}
+
+func TestComputeDesiredState_RecordsOwningPackage(t *testing.T) {
+	target := domain.NewTargetPath("/home/user").Unwrap()
+	pkg := buildTestPackage(t, "/dotfiles/vim", "vim", "dot-vimrc", "dot-vim/colors/desert.vim")
+
+	result := planner.ComputeDesiredState([]domain.Package{pkg}, target, false)
+	require.True(t, result.IsOk())
+
+	state := result.Unwrap()
+	for path, link := range state.Links {
+		assert.Equal(t, "vim", link.Package, "link %s must record its owning package", path)
+	}
+	for path, dir := range state.Dirs {
+		assert.Equal(t, "vim", dir.Package, "dir %s must record its owning package", path)
+	}
+}

--- a/internal/planner/desired_test.go
+++ b/internal/planner/desired_test.go
@@ -413,7 +413,7 @@ func TestComputeDesiredState_PackageNameMapping(t *testing.T) {
 
 	t.Run("with package name mapping disabled", func(t *testing.T) {
 		// Package "dot-gnupg" with file "common.conf"
-		// Should produce target "~/common.conf" (legacy behavior)
+		// Should produce target "~/common.conf" (stow-style full-tree layout)
 		pkgPath := domain.NewPackagePath("/home/user/dotfiles/dot-gnupg").Unwrap()
 		target := domain.NewTargetPath("/home/user").Unwrap()
 

--- a/pkg/dot/client_exhaustive_test.go
+++ b/pkg/dot/client_exhaustive_test.go
@@ -142,7 +142,7 @@ func TestClient_PlanManage_MultiplePackages(t *testing.T) {
 	for _, pkg := range pkgs {
 		pkgDir := filepath.Join("/test/packages", pkg)
 		require.NoError(t, fs.MkdirAll(ctx, pkgDir, 0755))
-		require.NoError(t, fs.WriteFile(ctx, pkgDir+"/dot-file", []byte("x"), 0644))
+		require.NoError(t, fs.WriteFile(ctx, pkgDir+"/dot-file-"+pkg, []byte("x"), 0644))
 	}
 	require.NoError(t, fs.MkdirAll(ctx, "/test/target", 0755))
 
@@ -177,7 +177,7 @@ func TestClient_PlanUnmanage_MultiplePackages(t *testing.T) {
 	for _, pkg := range pkgs {
 		pkgDir := filepath.Join("/test/packages", pkg)
 		require.NoError(t, fs.MkdirAll(ctx, pkgDir, 0755))
-		require.NoError(t, fs.WriteFile(ctx, pkgDir+"/dot-file", []byte("x"), 0644))
+		require.NoError(t, fs.WriteFile(ctx, pkgDir+"/dot-file-"+pkg, []byte("x"), 0644))
 	}
 	require.NoError(t, fs.MkdirAll(ctx, "/test/target", 0755))
 

--- a/pkg/dot/errors.go
+++ b/pkg/dot/errors.go
@@ -17,6 +17,13 @@ type ErrPackageNotFound = domain.ErrPackageNotFound
 // ErrConflict represents a conflict during installation.
 type ErrConflict = domain.ErrConflict
 
+// ErrDuplicateTarget represents two packages claiming the same target path.
+type ErrDuplicateTarget = domain.ErrDuplicateTarget
+
+// ErrTargetKindConflict represents one package wanting a target path to be a
+// link while another needs it to be a directory.
+type ErrTargetKindConflict = domain.ErrTargetKindConflict
+
 // ErrCyclicDependency represents a dependency cycle error.
 type ErrCyclicDependency = domain.ErrCyclicDependency
 

--- a/pkg/dot/manage_service.go
+++ b/pkg/dot/manage_service.go
@@ -408,6 +408,46 @@ func (s *ManageService) PlanRemanage(ctx context.Context, packages ...string) (P
 	}, nil
 }
 
+// remanageConflictError converts the conflicts of a per-package remanage plan
+// into an error. The pipeline resolves a collision with an existing link as a
+// wrong-link conflict and omits the operation, so without this check a
+// remanage would silently skip the link and record the package with no links.
+// A conflict whose existing destination lives inside another package's
+// directory is reported as ErrDuplicateTarget naming both packages; anything
+// else falls back to the generic conflict error.
+func (s *ManageService) remanageConflictError(ctx context.Context, pkg string, plan Plan) error {
+	if len(plan.Metadata.Conflicts) == 0 {
+		return nil
+	}
+	for _, conflict := range plan.Metadata.Conflicts {
+		dest, err := s.fs.ReadLink(ctx, conflict.Path)
+		if err != nil {
+			continue
+		}
+		if owner, ok := s.packageOwningPath(dest); ok && owner != pkg {
+			return ErrDuplicateTarget{
+				TargetPath:    conflict.Path,
+				FirstPackage:  owner,
+				SecondPackage: pkg,
+			}
+		}
+	}
+	return checkPlanConflicts(plan)
+}
+
+// packageOwningPath reports which package directory contains path, if any.
+func (s *ManageService) packageOwningPath(path string) (string, bool) {
+	rel, err := filepath.Rel(s.packageDir, path)
+	if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
+		return "", false
+	}
+	first := strings.SplitN(filepath.ToSlash(rel), "/", 2)[0]
+	if first == "" {
+		return "", false
+	}
+	return first, true
+}
+
 // claimLinkTargets records the link targets ops creates on behalf of pkg,
 // rejecting any target a different package has already claimed. Re-claiming a
 // target for the same package (a package listed twice) is a no-op.
@@ -479,6 +519,9 @@ func (s *ManageService) planNewPackageInstall(ctx context.Context, pkg string) (
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	if err := s.remanageConflictError(ctx, pkg, pkgPlan); err != nil {
+		return nil, nil, nil, err
+	}
 	packageOps := make(map[string][]OperationID)
 	if pkgPlan.PackageOperations != nil {
 		if pkgOps, hasPkg := pkgPlan.PackageOperations[pkg]; hasPkg {
@@ -526,6 +569,9 @@ func (s *ManageService) planFullRemanage(ctx context.Context, pkg string) ([]Ope
 	// Get manage operations (scanner will now not see the old symlinks)
 	managePlan, err := s.PlanManage(ctx, pkg)
 	if err != nil {
+		return nil, nil, nil, err
+	}
+	if err := s.remanageConflictError(ctx, pkg, managePlan); err != nil {
 		return nil, nil, nil, err
 	}
 
@@ -582,6 +628,9 @@ func (s *ManageService) planAdoptedPackageRemanage(ctx context.Context, pkg stri
 	// Re-run the normal manage pipeline to create file-level symlinks
 	managePlan, err := s.PlanManage(ctx, pkg)
 	if err != nil {
+		return nil, nil, nil, err
+	}
+	if err := s.remanageConflictError(ctx, pkg, managePlan); err != nil {
 		return nil, nil, nil, err
 	}
 

--- a/pkg/dot/manage_service.go
+++ b/pkg/dot/manage_service.go
@@ -371,9 +371,17 @@ func (s *ManageService) PlanRemanage(ctx context.Context, packages ...string) (P
 	packageOps := make(map[string][]OperationID)
 	skippedLinks := make(map[string][]string)
 
+	// Remanage plans each package on its own, so the planner guard over one
+	// shared desired state never sees a cross-package collision. Track the
+	// claimed link targets here instead.
+	claimedTargets := make(map[string]string)
+
 	for _, pkg := range packages {
 		ops, pkgOpsMap, pkgSkipped, err := s.planSinglePackageRemanage(ctx, pkg, &m, hasher)
 		if err != nil {
+			return Plan{}, err
+		}
+		if err := claimLinkTargets(claimedTargets, pkg, ops); err != nil {
 			return Plan{}, err
 		}
 		allOperations = append(allOperations, ops...)
@@ -398,6 +406,30 @@ func (s *ManageService) PlanRemanage(ctx context.Context, packages ...string) (P
 		PackageOperations:   packageOps,
 		PackageSkippedLinks: skippedLinks,
 	}, nil
+}
+
+// claimLinkTargets records the link targets ops creates on behalf of pkg,
+// rejecting any target a different package has already claimed. Re-claiming a
+// target for the same package (a package listed twice) is a no-op.
+func claimLinkTargets(claimed map[string]string, pkg string, ops []Operation) error {
+	for _, op := range ops {
+		link, isLink := op.(LinkCreate)
+		if !isLink {
+			continue
+		}
+
+		target := link.Target.String()
+		if owner, seen := claimed[target]; seen && owner != pkg {
+			return ErrDuplicateTarget{
+				TargetPath:    target,
+				FirstPackage:  owner,
+				SecondPackage: pkg,
+			}
+		}
+		claimed[target] = pkg
+	}
+
+	return nil
 }
 
 // planSinglePackageRemanage plans remanage for a single package using hash comparison.

--- a/pkg/dot/remanage_duplicate_target_test.go
+++ b/pkg/dot/remanage_duplicate_target_test.go
@@ -1,0 +1,122 @@
+package dot_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yaklabco/dot/internal/adapters"
+	"github.com/yaklabco/dot/pkg/dot"
+)
+
+// remanageDuplicateClient builds an in-memory client whose packages each
+// contain the given relative files. Nothing outside the MemFS is touched.
+func remanageDuplicateClient(t *testing.T, packages map[string][]string) (*dot.Client, context.Context) {
+	t.Helper()
+
+	fs := adapters.NewMemFS()
+	ctx := context.Background()
+
+	require.NoError(t, fs.MkdirAll(ctx, "/test/target", 0755))
+	for pkg, files := range packages {
+		require.NoError(t, fs.MkdirAll(ctx, "/test/packages/"+pkg, 0755))
+		for _, file := range files {
+			require.NoError(t, fs.WriteFile(ctx, "/test/packages/"+pkg+"/"+file, []byte(pkg), 0644))
+		}
+	}
+
+	client, err := dot.NewClient(dot.Config{
+		PackageDir: "/test/packages",
+		TargetDir:  "/test/target",
+		FS:         fs,
+		Logger:     adapters.NewNoopLogger(),
+	})
+	require.NoError(t, err)
+
+	return client, ctx
+}
+
+// TestPlanRemanageRejectsDuplicateTargets covers the remanage path, which plans
+// each package on its own rather than through one shared desired state. The
+// per-package plans must still be checked against each other.
+func TestPlanRemanageRejectsDuplicateTargets(t *testing.T) {
+	tests := []struct {
+		name         string
+		packages     map[string][]string
+		args         []string
+		wantErr      bool
+		wantContains []string
+	}{
+		{
+			name: "two packages claiming the same file collide",
+			packages: map[string][]string{
+				"base":    {"dot-vimrc"},
+				"overlay": {"dot-vimrc"},
+			},
+			args:         []string{"base", "overlay"},
+			wantErr:      true,
+			wantContains: []string{"/test/target/.vimrc", "base", "overlay"},
+		},
+		{
+			name: "distinct files in the same directory do not collide",
+			packages: map[string][]string{
+				"base":    {"dot-vimrc"},
+				"overlay": {"dot-zshrc"},
+			},
+			args:    []string{"base", "overlay"},
+			wantErr: false,
+		},
+		{
+			name: "a single package is unaffected",
+			packages: map[string][]string{
+				"base": {"dot-vimrc"},
+			},
+			args:    []string{"base"},
+			wantErr: false,
+		},
+		{
+			name: "the same package named twice is not a collision",
+			packages: map[string][]string{
+				"base": {"dot-vimrc"},
+			},
+			args:    []string{"base", "base"},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, ctx := remanageDuplicateClient(t, tt.packages)
+
+			_, err := client.PlanRemanage(ctx, tt.args...)
+
+			if !tt.wantErr {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			var duplicate dot.ErrDuplicateTarget
+			require.ErrorAs(t, err, &duplicate)
+			for _, want := range tt.wantContains {
+				assert.Contains(t, err.Error(), want)
+			}
+		})
+	}
+}
+
+// TestRemanageRejectsDuplicateTargets checks the executing path, not just the
+// planning path, so no link is created for a colliding pair.
+func TestRemanageRejectsDuplicateTargets(t *testing.T) {
+	client, ctx := remanageDuplicateClient(t, map[string][]string{
+		"base":    {"dot-vimrc"},
+		"overlay": {"dot-vimrc"},
+	})
+
+	err := client.Remanage(ctx, "base", "overlay")
+
+	require.Error(t, err)
+	var duplicate dot.ErrDuplicateTarget
+	assert.ErrorAs(t, err, &duplicate)
+}

--- a/pkg/dot/remanage_duplicate_target_test.go
+++ b/pkg/dot/remanage_duplicate_target_test.go
@@ -12,7 +12,7 @@ import (
 
 // remanageDuplicateClient builds an in-memory client whose packages each
 // contain the given relative files. Nothing outside the MemFS is touched.
-func remanageDuplicateClient(t *testing.T, packages map[string][]string) (*dot.Client, context.Context) {
+func remanageDuplicateClient(t *testing.T, packages map[string][]string) (*dot.Client, *adapters.MemFS, context.Context) {
 	t.Helper()
 
 	fs := adapters.NewMemFS()
@@ -34,7 +34,7 @@ func remanageDuplicateClient(t *testing.T, packages map[string][]string) (*dot.C
 	})
 	require.NoError(t, err)
 
-	return client, ctx
+	return client, fs, ctx
 }
 
 // TestPlanRemanageRejectsDuplicateTargets covers the remanage path, which plans
@@ -87,7 +87,7 @@ func TestPlanRemanageRejectsDuplicateTargets(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, ctx := remanageDuplicateClient(t, tt.packages)
+			client, _, ctx := remanageDuplicateClient(t, tt.packages)
 
 			_, err := client.PlanRemanage(ctx, tt.args...)
 
@@ -109,7 +109,7 @@ func TestPlanRemanageRejectsDuplicateTargets(t *testing.T) {
 // TestRemanageRejectsDuplicateTargets checks the executing path, not just the
 // planning path, so no link is created for a colliding pair.
 func TestRemanageRejectsDuplicateTargets(t *testing.T) {
-	client, ctx := remanageDuplicateClient(t, map[string][]string{
+	client, _, ctx := remanageDuplicateClient(t, map[string][]string{
 		"base":    {"dot-vimrc"},
 		"overlay": {"dot-vimrc"},
 	})
@@ -119,4 +119,55 @@ func TestRemanageRejectsDuplicateTargets(t *testing.T) {
 	require.Error(t, err)
 	var duplicate dot.ErrDuplicateTarget
 	assert.ErrorAs(t, err, &duplicate)
+}
+
+// TestRemanageRejectsCollisionWithManagedPackage covers the first-time
+// collision against a package that is already installed: vim owns .rc on disk
+// and in the manifest, then emacs gains a colliding dot-rc. The per-package
+// remanage plan for emacs resolves the collision as a wrong-link conflict and
+// omits the operation, so the claim guard over planned operations never sees
+// it. The conflict must surface as an error naming both packages, not vanish
+// into an exit-0 remanage that records emacs with zero links.
+func TestRemanageRejectsCollisionWithManagedPackage(t *testing.T) {
+	client, _, ctx := remanageDuplicateClient(t, map[string][]string{
+		"vim":   {"dot-rc"},
+		"emacs": {"dot-erc", "dot-rc"},
+	})
+
+	require.NoError(t, client.Manage(ctx, "vim"))
+
+	err := client.Remanage(ctx, "vim", "emacs")
+
+	require.Error(t, err)
+	var duplicate dot.ErrDuplicateTarget
+	require.ErrorAs(t, err, &duplicate)
+	assert.Contains(t, err.Error(), "/test/target/.rc")
+	assert.Contains(t, err.Error(), "vim")
+	assert.Contains(t, err.Error(), "emacs")
+
+	// The failed remanage must not have half-registered emacs.
+	status, statusErr := client.Status(ctx, "emacs")
+	if statusErr == nil {
+		for _, pkg := range status.Packages {
+			if pkg.Name == "emacs" {
+				assert.NotEmpty(t, pkg.Links,
+					"emacs must not be recorded with zero links after a rejected remanage")
+			}
+		}
+	}
+}
+
+// TestRemanageForeignConflictStillErrors ensures the conflict fallback holds
+// when the blocking target is not owned by any package: a plain file the user
+// created. The error is the generic conflict error, but it must be an error.
+func TestRemanageForeignConflictStillErrors(t *testing.T) {
+	client, fs, ctx := remanageDuplicateClient(t, map[string][]string{
+		"vim": {"dot-rc"},
+	})
+
+	require.NoError(t, fs.WriteFile(ctx, "/test/target/.rc", []byte("user file"), 0644))
+
+	err := client.Remanage(ctx, "vim")
+
+	require.Error(t, err)
 }

--- a/tests/integration/benchmark_test.go
+++ b/tests/integration/benchmark_test.go
@@ -43,7 +43,7 @@ func BenchmarkManage_10Packages(b *testing.B) {
 			pkgName := filepath.Join("pkg", string(rune('a'+j)))
 			packages[j] = pkgName
 			env.FixtureBuilder().Package(pkgName).
-				WithFile("dot-file", "content").
+				WithFile("dot-file-"+filepath.Base(pkgName), "content").
 				Create()
 		}
 
@@ -69,7 +69,7 @@ func BenchmarkManage_100Packages(b *testing.B) {
 			pkgName += string(rune('0' + (j / 26)))
 			packages[j] = pkgName
 			env.FixtureBuilder().Package(pkgName).
-				WithFile("dot-file", "content").
+				WithFile("dot-file-"+filepath.Base(pkgName), "content").
 				Create()
 		}
 
@@ -143,7 +143,7 @@ func BenchmarkStatus_Query(b *testing.B) {
 	for j := 0; j < 10; j++ {
 		pkgName := filepath.Join("pkg", string(rune('a'+j)))
 		env.FixtureBuilder().Package(pkgName).
-			WithFile("dot-file", "content").
+			WithFile("dot-file-"+filepath.Base(pkgName), "content").
 			Create()
 	}
 
@@ -176,7 +176,7 @@ func BenchmarkList_Query(b *testing.B) {
 	for j := 0; j < 10; j++ {
 		pkgName := filepath.Join("pkg", string(rune('a'+j)))
 		env.FixtureBuilder().Package(pkgName).
-			WithFile("dot-file", "content").
+			WithFile("dot-file-"+filepath.Base(pkgName), "content").
 			Create()
 	}
 
@@ -232,7 +232,7 @@ func BenchmarkDoctor_HealthCheck(b *testing.B) {
 	for j := 0; j < 5; j++ {
 		pkgName := filepath.Join("pkg", string(rune('a'+j)))
 		env.FixtureBuilder().Package(pkgName).
-			WithFile("dot-file", "content").
+			WithFile("dot-file-"+filepath.Base(pkgName), "content").
 			Create()
 	}
 

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -441,7 +441,7 @@ func TestCLI_LongRunningOperation(t *testing.T) {
 			pkgName += string(rune('0' + (i / 26)))
 		}
 		env.FixtureBuilder().Package(pkgName).
-			WithFile("dot-file", "content").
+			WithFile("dot-file-"+filepath.Base(pkgName), "content").
 			Create()
 	}
 

--- a/tests/integration/concurrent_test.go
+++ b/tests/integration/concurrent_test.go
@@ -21,7 +21,7 @@ func TestConcurrent_ParallelPackageScanning(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		pkgName := filepath.Join("pkg", string(rune('a'+i)))
 		env.FixtureBuilder().Package(pkgName).
-			WithFile("dot-file", "content").
+			WithFile("dot-file-"+filepath.Base(pkgName), "content").
 			Create()
 	}
 
@@ -73,7 +73,7 @@ func TestConcurrent_StatusQueriesDuringManage(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		pkgName := filepath.Join("pkg", string(rune('a'+i)))
 		env.FixtureBuilder().Package(pkgName).
-			WithFile("dot-file", "content").
+			WithFile("dot-file-"+filepath.Base(pkgName), "content").
 			Create()
 	}
 
@@ -146,7 +146,7 @@ func TestConcurrent_ParallelExecutionBatches(t *testing.T) {
 		pkgName := filepath.Join("pkg", string(rune('a'+i)))
 		pkg := env.FixtureBuilder().Package(pkgName)
 		for j := 0; j < 3; j++ {
-			pkg.WithFile("dot-file"+string(rune('a'+j)), "content")
+			pkg.WithFile("dot-file-"+filepath.Base(pkgName)+string(rune('a'+j)), "content")
 		}
 		pkg.Create()
 	}
@@ -174,7 +174,7 @@ func TestConcurrent_CancellationDuringExecution(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		pkgName := filepath.Join("pkg", string(rune('a'+i)))
 		env.FixtureBuilder().Package(pkgName).
-			WithFile("dot-file", "content").
+			WithFile("dot-file-"+filepath.Base(pkgName), "content").
 			Create()
 	}
 
@@ -207,7 +207,7 @@ func TestConcurrent_StressTest(t *testing.T) {
 			pkgName += string(rune('0' + (i / 26)))
 		}
 		env.FixtureBuilder().Package(pkgName).
-			WithFile("dot-file", "content").
+			WithFile("dot-file-"+filepath.Base(pkgName), "content").
 			Create()
 	}
 
@@ -240,7 +240,7 @@ func TestConcurrent_NoRaceConditions(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		pkgName := filepath.Join("pkg", string(rune('a'+i)))
 		env.FixtureBuilder().Package(pkgName).
-			WithFile("dot-file", "content").
+			WithFile("dot-file-"+filepath.Base(pkgName), "content").
 			Create()
 	}
 

--- a/tests/integration/query_test.go
+++ b/tests/integration/query_test.go
@@ -188,7 +188,7 @@ func TestQuery_Status_Performance(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		pkgName := filepath.Join("pkg", string(rune('a'+i)))
 		env.FixtureBuilder().Package(pkgName).
-			WithFile("dot-file", "content").
+			WithFile("dot-file-"+filepath.Base(pkgName), "content").
 			Create()
 	}
 

--- a/tests/integration/scenario_test.go
+++ b/tests/integration/scenario_test.go
@@ -158,7 +158,7 @@ func TestScenario_LargeRepository(t *testing.T) {
 		packages[i] = pkgName
 
 		env.FixtureBuilder().Package(pkgName).
-			WithFile("dot-file", "content").
+			WithFile("dot-file-"+filepath.Base(pkgName), "content").
 			Create()
 	}
 


### PR DESCRIPTION
Plan-time guard for overlay-package workflows: two packages claiming the same target path now fail with an error naming both packages and the path, on the manage, remanage, and clone paths. Includes dir-vs-file collision detection in both walk orders, remanage conflict surfacing (a first-time collision with an already-managed package previously exited 0 and silently skipped the link), actionable remediation text, and de-legacied planner comments. TDD throughout; suite and lint green.