### PR TITLE
ci(release): let feature commits bump the minor version before 1.0

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -6,7 +6,6 @@
       "package-name": "dot",
       "include-component-in-tag": false,
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [
         {"type": "feat", "section": "Features"},
         {"type": "fix", "section": "Bug Fixes"},


### PR DESCRIPTION
bump-patch-for-minor-pre-major demoted every feat to a patch bump, so the pending feature release computed 0.6.7 instead of 0.7.0. Removing it lets bump-minor-pre-major do its job: features bump minor, breaking changes still bump minor rather than major until 1.0. The open release PR should retarget to 0.7.0 on merge.